### PR TITLE
Constrain annototation creation, updating, and deleting to api_key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     almond-rails (0.1.0)
       rails (>= 4.2, < 6)
-    annotot (0.4.0)
+    annotot (0.5.0)
       rails (~> 5.1)
     archive-zip (0.11.0)
       io-like (~> 0.3.0)

--- a/app/models/api_authorization/constraint.rb
+++ b/app/models/api_authorization/constraint.rb
@@ -1,0 +1,17 @@
+module ApiAuthorization
+  ##
+  # Constraint used gate API access to annotations
+  class Constraint
+    def matches?(request)
+      return true if request.get? || valid_api_key?(request)
+      raise ApiAuthorization::Unauthorized
+    end
+
+    def valid_api_key?(request)
+      ActiveSupport::SecurityUtils.secure_compare(
+        ::Digest::SHA256.hexdigest(request.headers['Authorization'].to_s),
+        ::Digest::SHA256.hexdigest(Settings.annotations.api_key.to_s)
+      )
+    end
+  end
+end

--- a/app/models/api_authorization/unauthorized.rb
+++ b/app/models/api_authorization/unauthorized.rb
@@ -1,0 +1,4 @@
+module ApiAuthorization
+  class Unauthorized < StandardError
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,11 @@ module VaticanExhibits
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    
+    config.action_dispatch.rescue_responses.merge!(
+      'ApiAuthorization::Unauthorized' => :unauthorized
+    )
+
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  mount Annotot::Engine => '/'
+  mount Annotot::Engine => '/', constraints: (ApiAuthorization::Constraint.new if Settings.annotations.secure)
   authenticate :user, lambda { |u| u.superadmin? } do
     require 'sidekiq/web'
     Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,7 +3,9 @@ action_mailer:
     from: "noreply@example.com"
   default_url_options:
     host: "localhost:3000"
-
+annotations:
+  secure: true
+  api_key: 'test123'
 vatican_iiif_resource:
   iiif_template_url: https://digi.vatlib.it/iiif/{shelfmark}/manifest.json
   # TEI metadata URL pattern

--- a/spec/factories/annotations.rb
+++ b/spec/factories/annotations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :annotation, class: Annotot::Annotation do
+    uuid { SecureRandom.hex }
+    canvas 'http://www.example.com/hola'
+    data ''
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require 'devise'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'factory_bot_rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
@@ -46,6 +47,8 @@ RSpec.configure do |config|
     config.include Devise::TestHelpers, type: :controller
     config.include Devise::TestHelpers, type: :view
   end
+
+  config.include FactoryBot::Syntax::Methods
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/requests/annotations_spec.rb
+++ b/spec/requests/annotations_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe 'Annotation Requests', type: :request do
+  context 'without an API key' do
+    it 'index returns annotations' do
+      get '/annotations', params: { uri: 'http://example.com/canvas' }
+      expect(response.content_type).to eq('application/json')
+      expect(JSON.parse(response.body)).to eq []
+      expect(response).to have_http_status(:ok)
+    end
+    it 'list returns annotations' do
+      get '/annotations/lists', params: { uri: 'http://example.com/canvas' }
+      expect(response.content_type).to eq('application/json')
+      expect(response).to have_http_status(:ok)
+    end
+    it 'update raises unauthorized' do
+      expect do
+        patch '/annotations/1', params: { uri: 'http://example.com/canvas' }
+      end.to raise_error ApiAuthorization::Unauthorized
+    end
+    it 'destroy raises unauthorized' do
+      expect do
+        delete '/annotations/1', params: { uri: 'http://example.com/canvas' }
+      end.to raise_error ApiAuthorization::Unauthorized
+    end
+    it 'post raises unauthorized' do
+      expect do
+        post '/annotations', params: { uri: 'http://example.com/canvas' }
+      end.to raise_error ApiAuthorization::Unauthorized
+    end
+  end
+  context 'with an API key' do
+    let(:anno) { FactoryBot.create(:annotation) }
+    let(:valid_attributes) do
+      {
+        data: 'super cool anno data',
+        canvas: 'http://example.com/canvas'
+      }
+    end
+
+    it 'update successfully updates' do
+      patch "/annotations/#{anno.id}",
+            params: { format: :json, annotation: valid_attributes },
+            headers: { 'Authorization' => 'test123' }
+      expect(response.content_type).to eq('application/json')
+      anno.reload
+      expect(anno.data).to eq 'super cool anno data'
+    end
+    it 'destroy raises unauthorized' do
+      delete "/annotations/#{anno.id}",
+             params: { format: :json },
+             headers: { 'Authorization' => 'test123' }
+      expect(response.status).to be 200
+    end
+    it 'post creates a new annotation' do
+      post '/annotations',
+           params: { format: :json, annotation: valid_attributes.merge(uuid: 'abc123') },
+           headers: { 'Authorization' => 'test123' }
+      expect(response.status).to be 200
+    end
+  end
+end


### PR DESCRIPTION
Allows us to serve up annotations publicly for consumption 🍔 but at the same time restrict who can edit them.

Ajax requests using this (like annotot for mirador) https://github.com/mejackreed/annotot/blob/master/app/assets/javascripts/annotot/annotot_endpoint.js#L72 can update like so:

```diff
      jQuery.ajax({
        url: _this.endpoint + '/' + encodeURIComponent(annotationID),
        type: 'DELETE',
        dataType: 'json',
        headers: {
+       'Authorization': 'test123'
          // 'X-CSRF-Token': _this.csrfToken()
        },
```

Partially addresses #76 