### PR TITLE
Add a textarea for entering a Mirador config

### DIFF
--- a/app/assets/javascripts/zpotlight/blocks/mirador_block.js
+++ b/app/assets/javascripts/zpotlight/blocks/mirador_block.js
@@ -74,6 +74,10 @@ SirTrevor.Blocks.Mirador = (function() {
           '<label for="<%= blockID + "_caption"  %>" class="control-label"><%= i18n.t("blocks:mirador:caption_label") %></label>',
           '<input type="text" name="caption" />',
         '</div>',
+        '<div>',
+          '<label for="mirador_config">Mirador config</label>',
+          '<textarea name="mirador_config" class="form-control"></textarea>',
+        '</div>',
       '</div>'
     ].join("\n")
   });

--- a/app/controllers/mirador_controller.rb
+++ b/app/controllers/mirador_controller.rb
@@ -9,7 +9,8 @@ class MiradorController < ApplicationController
   private
 
   def set_mirador_params
-    @manifest = params.require(:manifest)
+    @manifest = params.fetch(:manifest, nil)
     @canvas = params.fetch(:canvas, nil)
+    @options = params.fetch(:options, nil)
   end
 end

--- a/app/helpers/mirador_helper.rb
+++ b/app/helpers/mirador_helper.rb
@@ -3,6 +3,7 @@ module MiradorHelper
   # rubocop:disable MethodLength
   def mirador_options(manifest, canvas)
     {
+      "language": I18n.default_locale,
       "mainMenuSettings": {
         "show":  false
       },

--- a/app/views/mirador/index.html.erb
+++ b/app/views/mirador/index.html.erb
@@ -2,4 +2,4 @@
 <%= javascript_include_tag "mirador_bundle" %>
 
 <%= mirador_tag(:height => "100%",
-                :options => mirador_options(@manifest, @canvas)) %>
+                :options => @options.present? ? JSON.parse(@options) : mirador_options(@manifest, @canvas)) %>

--- a/app/views/spotlight/sir_trevor/blocks/_mirador_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_mirador_block.html.erb
@@ -10,4 +10,20 @@
     </ul>
   <% end %>
   <div><%= mirador_block.caption %></div>
+  <div><%= mirador_block.mirador_config %></div>
+
+  <iframe
+      src="<%= mirador_index_path(
+        options: mirador_block.mirador_config
+      ) %>"
+      allowfullscreen="true"
+      class="mirador-embed-wrapper"
+      frameborder="0"
+      marginwidth="0"
+      marginheight="0"
+      scrolling="no"
+      width="100%"
+    ></iframe>
+
+
 </div>

--- a/spec/features/mirador_widget_spec.rb
+++ b/spec/features/mirador_widget_spec.rb
@@ -35,4 +35,49 @@ RSpec.describe 'Mirador Block', type: :feature, js: true do
       expect(page).to have_content 'The Caption'
     end
   end
+
+  describe 'mirador config' do
+    let(:mirador_config) do
+      '{
+        "language": "en",
+        "mainMenuSettings": {
+          "show": false
+        },
+        "buildPath": "/assets/",
+        "saveSession": false,
+        "data": [{
+          "manifestUri": "https://purl.stanford.edu/nb647fd0133/iiif/manifest",
+          "location": "Biblioteca Apostolica Vaticana"
+        },
+        {
+          "manifestUri": "https://purl.stanford.edu/cf386wt1778/iiif/manifest",
+          "location": "Biblioteca Apostolica Vaticana"
+        }
+      ],
+        "windowObjects": [{
+            "loadedManifest": "https://purl.stanford.edu/nb647fd0133/iiif/manifest",
+            "bottomPanelVisible": false,
+            "annotationCreation": false,
+            "canvasControls": {
+              "annotations": {
+                "annotationLayer": true,
+                "annotationState": "on"
+              }
+            }
+          }
+        ]
+      }'
+    end
+
+    it 'parses provided JSON' do
+      visit spotlight.edit_exhibit_home_page_path(exhibit)
+
+      add_widget 'mirador'
+      # this textarea will become a hidden input vatican-exhibits#88
+      input = find('textarea[name="mirador_config"]', visible: true)
+      input.set(mirador_config.to_s)
+      save_page
+      expect(page).to have_css 'iframe[src*=mirador]'
+    end
+  end
 end


### PR DESCRIPTION
Addresses #69 and #74 

## Notes
- This textarea is a temporary implementation that will eventually be overwritten by #88
- size limits for POST requests --> [MessagePack](https://github.com/msgpack/msgpack-ruby)? PostMessage?
- "language" setting is required for `mirador_rails`

### Simple mirador config
```
{
  "language": "en",
  "mainMenuSettings": {
    "show": false
  },
  "buildPath": "/assets/",
  "saveSession": false,
  "data": [{
    "manifestUri": "https://purl.stanford.edu/nb647fd0133/iiif/manifest",
    "location": "Biblioteca Apostolica Vaticana"
  },
  {
    "manifestUri": "https://purl.stanford.edu/cf386wt1778/iiif/manifest",
    "location": "Biblioteca Apostolica Vaticana"
  }
],
  "windowObjects": [{
      "loadedManifest": "https://purl.stanford.edu/nb647fd0133/iiif/manifest",
      "bottomPanelVisible": false,
      "annotationCreation": false,
      "canvasControls": {
        "annotations": {
          "annotationLayer": true,
          "annotationState": "on"
        }
      }
    },
    {
      "loadedManifest": "https://purl.stanford.edu/cf386wt1778/iiif/manifest",
      "bottomPanelVisible": false,
      "annotationCreation": false,
      "canvasControls": {
        "annotations": {
          "annotationLayer": true,
          "annotationState": "on"
        }
      }
    }
  ]
}
```