### PR TITLE
add no-sandbox flag to chrome-headless, needed on travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 
 before_install:
   - gem install bundler
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+  - google-chrome-stable --headless --no-sandbox --disable-gpu --remote-debugging-port=9222 http://localhost &
 
 before_script:
   - bin/rails db:test:prepare


### PR DESCRIPTION
There was an error in the travis log without this.