### PR TITLE
enables drag and drop of mirador things

### DIFF
--- a/app/assets/javascripts/zpotlight/blocks/mirador_block.js
+++ b/app/assets/javascripts/zpotlight/blocks/mirador_block.js
@@ -32,6 +32,7 @@ SirTrevor.Blocks.Mirador = (function() {
 
     onBlockRender: function() {
       MiradorWidgetAdmin.init();
+      SpotlightNestable.init($('[data-behavior="nestable"]', this.inner));
     },
 
     /**
@@ -69,7 +70,7 @@ SirTrevor.Blocks.Mirador = (function() {
         '<div class="widget-header">',
           '<%= description() %>',
         '</div>',
-        '<div class="panels dd nestable-item-grid">',
+        '<div class="panels dd nestable-item-grid" data-behavior="nestable" data-max-depth="1">',
           '<ol class="dd-list" data-behavior="items-section"></ol>',
         '</div>',
         '<fieldset class="mirador-source-location">',

--- a/spec/features/mirador_widget_spec.rb
+++ b/spec/features/mirador_widget_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'Mirador Block', type: :feature, js: true do
       page.all('textarea[name="text"]').first.set('The Text')
       page.all('input[name="caption"]').first.set('The Caption')
 
+      expect(page).to have_css '[data-behavior="nestable"]'
+
       save_page
 
       expect(page).to have_content 'The Heading'


### PR DESCRIPTION
Fixes #106 
Enables basic drag and drop of items in the Mirador Widget configuration page. One thing this doesn't do is change how they appear in the Mirador viewer. I think before implementing that piece, we need to  get the modal thing going as it will impact how this works significantly. It may make syncing this part and the mirador config a bit difficult.

![dnd](https://user-images.githubusercontent.com/1656824/41490422-4403a746-70b1-11e8-9b9e-1e0021065dc8.gif)
