### PR TITLE
Move adding items to mirador widget panel into the MiradorWidgetBlock…

### DIFF
--- a/app/assets/javascripts/mirador_widget_admin.js
+++ b/app/assets/javascripts/mirador_widget_admin.js
@@ -37,7 +37,7 @@
     // Setup functions that need ot listen to when an item is successfully added to the items array
     function setupItemAddedListener(block) {
       block.on('item-added', function(e, eventObject) {
-        appendItemToSection(eventObject.block, eventObject.manifest);
+        addIiifItemToSection(eventObject.block, eventObject.manifest);
         sourceLocationInput(eventObject.block).val('');
 
         eventObject.block.trigger('items-updated', eventObject.block);
@@ -86,20 +86,16 @@
        });
     }
 
-    function appendItemToSection(block, manifest) {
-      var index = block.find('input[type="hidden"][data-behavior="mirador-item"]').length;
-
+    function addIiifItemToSection(block, manifest) {
       if(typeof(manifest) == 'string') {
         manifest = JSON.parse(manifest);
       }
 
-      itemsSection(block).append(
-        MiradorWidgetBlock.hiddenInput(index, {
-          title: manifest.label,
-          thumbnail: manifest.thumbnail ? manifest.thumbnail['@id'] : manifest.sequences[0].canvases[0].thumbnail['@id'],
-          iiif_manifest_url: manifest['@id']
-        })
-      );
+      MiradorWidgetBlock.addItemToSection(block, {
+        title: manifest.label,
+        thumbnail: manifest.thumbnail ? manifest.thumbnail['@id'] : manifest.sequences[0].canvases[0].thumbnail['@id'],
+        iiif_manifest_url: manifest['@id']
+      }, false);
     }
 
     function sourceLocationSubmit(block) {
@@ -154,6 +150,22 @@
         ].join("\n");
 
         block.find('[name="mirador_config"]').replaceWith(_.template(template));
+      },
+
+      addItemToSection: function(block, itemObject, shouldTriggerEvent) {
+        var index = block.find('input[type="hidden"][data-behavior="mirador-item"]').length;
+
+        itemsSection(block).append(
+          MiradorWidgetBlock.hiddenInput(index, itemObject)
+        );
+
+        // When the shouldTriggerEvent option is set to true (or not set, as it is the default behavior)
+        // trigger the items-updated event.  Somebody calling MiradorWidgetBlock.addItemToSection should
+        // only set shouldTriggerEvent to false if they do not want adding the item to trigger events
+        // such as updating the mirador config based on the current items (e.g. Block initialization) 
+        if (shouldTriggerEvent || shouldTriggerEvent === undefined) {
+          block.trigger('items-updated', block);
+        }
       },
 
       setupEvents: function(block) {

--- a/app/assets/javascripts/zpotlight/blocks/mirador_block.js
+++ b/app/assets/javascripts/zpotlight/blocks/mirador_block.js
@@ -40,29 +40,21 @@ SirTrevor.Blocks.Mirador = (function() {
      * to add the updateHiddenMiradorConfig
      */
     createItemPanel: function(data) {
-      var panel = MiradorWidgetBlock.hiddenInput(this.globalIndex++, {
+      var block = $(this.el).find('[data-behavior="mirador-widget"]');
+      MiradorWidgetBlock.addItemToSection(block, {
         title: data.title,
         thumbnail: data.thumbnail,
         iiif_manifest_url: data.iiif_manifest,
         id: data.id
       });
-      $(panel).appendTo($('.panels > ol', this.inner));
-      var block = $(this.el).find('[data-behavior="mirador-widget"]');
-      block.trigger('items-updated', block);
+
       $('[data-behavior="nestable"]', this.inner).trigger('change');
     },
 
     afterLoadData: function(data) {
-      var context = this;
-      var itemsSection = $(this.$('[data-behavior="items-section"]'));
-      var i = 0;
+      var block = $(this.el).find('[data-behavior="mirador-widget"]');
       $.each(data.items, function(key, item) {
-        itemsSection.append(
-          MiradorWidgetBlock.hiddenInput(i, item)
-        );
-        context.globalIndex++; // Make sure to update the globalIndex
-
-        i++;
+        MiradorWidgetBlock.addItemToSection(block, item, false);
       });
     },
 


### PR DESCRIPTION
… object.

This fixes an issue where depending on which combination of exhibit items and iiif items were added, some would end up with a duplicate name attribute (due to index handling) and only one of the duplicates would be persisted.

This moves that index handling (along with the process of adding an item) to a central place so they don't get out of sync.