### PR TITLE
Add explicit layouts and slotAddresses when over 1 mirador item is added

### DIFF
--- a/app/assets/javascripts/mirador_serializer.es6
+++ b/app/assets/javascripts/mirador_serializer.es6
@@ -17,11 +17,35 @@ export default class MiradorSerializer {
         manifestUri: url,
       })),
       layout: this.layout(),
-      windowObjects: this.manifestUrls.map(url => ({
+      windowObjects: this.manifestUrls.map((url, index) => ({
         loadedManifest: url,
         viewType: 'ImageView',
+        slotAddress: this.slotAddress(index, this.manifestUrls.length)
       })),
     };
+  }
+
+  /**
+   * A Mirador slot address based on image position
+   * @returns {(string|null)}
+   */
+  slotAddress(index, total) {
+    if(total < 2) {
+      return null;
+    }
+
+    switch(index) {
+      case 0:
+        return 'column1.row1.column1';
+      case 1:
+        return 'column1.row1.column2';
+      case 2:
+        return 'column1.row2.column1';
+      case 3:
+        return 'column1.row2.column2';
+      default:
+        return null;
+    }
   }
 
   /**
@@ -33,13 +57,84 @@ export default class MiradorSerializer {
       case 1:
         return '1x1';
       case 2:
-        return '1x2';
+        return this.twoUpLayout();
       case 3:
-        return '2x2'; // TODO: Fix this if there is a better layout
+        return this.twoUpOneAcrossLayout();
       case 4:
-        return '2x2';
+        return this.twoByTwoLayout();
       default:
         return null;
     }
+  }
+
+  /**
+   * Creates a mirador layout object for a simple two up/side-by-side display
+   * @returns {object}
+   */
+  twoUpLayout() {
+    return {
+      type: 'column',
+      address: 'column1',
+      children: [
+        {
+          type: 'row',
+          address: 'column1.row1',
+          children: [
+            {
+              type: 'column',
+              depth: 2,
+              address: 'column1.row1.column1'
+            },
+            {
+              type: 'column',
+              depth: 2,
+              address: 'column1.row1.column2'
+            }
+          ]
+        }
+      ]
+    };
+  }
+
+  /**
+   * Creates a mirador layout object that has two rows,
+   * This builds off of the twoUpLayout() by adding a new row with a single column.
+   * @returns {object}
+   */
+  twoUpOneAcrossLayout() {
+    var layout = this.twoUpLayout();
+    layout.children.push(
+      {
+        type: 'row',
+        address: 'column1.row2',
+        children: [
+          {
+            type: 'column',
+            depth: 2,
+            address: 'column1.row2.column1'
+          }
+        ]
+      }
+    );
+
+    return layout;
+  }
+
+  /**
+   * Creates a mirador layout object that has two rows,
+   * This builds off of the twoUpOneAcrossLayout() by adding a new column to the second row.
+   * @returns {object}
+   */
+  twoByTwoLayout() {
+    var layout = this.twoUpOneAcrossLayout();
+    layout.children[1].children.push(
+      {
+        type: 'column',
+        depth: 2,
+        address: 'column1.row2.column2'
+      }
+    );
+
+    return layout;
   }
 }

--- a/spec/features/mirador_widget_spec.rb
+++ b/spec/features/mirador_widget_spec.rb
@@ -163,7 +163,8 @@ RSpec.describe 'Mirador Block', type: :feature, js: true do
         windowObjects: [
           {
             loadedManifest: 'https://digi.vatlib.it/iiif/MSS_Barb.gr.252/manifest.json',
-            viewType: 'ImageView'
+            viewType: 'ImageView',
+            slotAddress: nil
           }
         ]
       }.to_json


### PR DESCRIPTION
Mirador fills the available slots based on the order the manifests are loaded/returned
so it will not necessarily be the order that is passed in via windowObjects.

Closes #114 

<img width="872" alt="two-up-1-across" src="https://user-images.githubusercontent.com/96776/41803293-2a8c8658-763c-11e8-8d04-a6c51506e50a.png">