### PR TITLE
Update how mirador item form indexes are handled to not use element …

### DIFF
--- a/app/assets/javascripts/mirador_widget_admin.js
+++ b/app/assets/javascripts/mirador_widget_admin.js
@@ -153,7 +153,12 @@
       },
 
       addItemToSection: function(block, itemObject, shouldTriggerEvent) {
-        var index = block.find('input[type="hidden"][data-behavior="mirador-item"]').length;
+        var miradorItemIndexes = [];
+        block.find('input[type="hidden"][data-behavior="mirador-item"]').each(function() {
+          miradorItemIndexes.push(parseInt($(this).prop('name').match(/(\d)/)[0]) + 1);
+        });
+
+        var index = (miradorItemIndexes.sort().pop() || 0);
 
         itemsSection(block).append(
           MiradorWidgetBlock.hiddenInput(index, itemObject)


### PR DESCRIPTION
…length

If you remove the first item, the length is now two, however, w/o renaming
all form elements the last item index is also two, so we end up getting a clashing form name.

This commit changes the index handling to look at the indexes present in the form names, sort them, and ensure that we're incrementing.