### PR TITLE
Index and display bibliography elements for the manuscript and its…

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -63,6 +63,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'ms_extent_tesim', section: :general
     config.add_show_field 'ms_content_tesim', section: :general
     config.add_show_field 'ms_overview_tesim', section: :general
+    config.add_show_field 'ms_bibl_tesim', section: :general
     config.add_show_field 'ms_collation_tesim'
     config.add_show_field 'ms_layout_tesim'
     config.add_show_field 'ms_foliation_tesim'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
         ms_extent_tesim: Extent
         ms_content_tesim: Content
         ms_overview_tesim: Overview
+        ms_bibl_tesim: Bibliography
         ms_collation_tesim: Collation
         ms_layout_tesim: Layout
         ms_foliation_tesim: Foliation

--- a/lib/traject/vatican_iiif_config.rb
+++ b/lib/traject/vatican_iiif_config.rb
@@ -184,6 +184,7 @@ compose ->(record, accumulator, _context) { accumulator << record.tei.xpath('//T
   to_field 'ms_alphabet_tesim', extract_xml('msPart/msContents/msItem/textLang', nil) #	Alfabeto	Alphabet
   to_field 'ms_colophon_tesim', extract_xml('msPart/msContents/msItem/colophon', nil) #	Colophon	Colophon
   to_field 'ms_secfol_tesim', extract_xml('msPart/msContents/msItem/writingSystem/secFol', nil) #	Secundum Folium	Secundum Folium
+  to_field 'ms_bibl_tesim', extract_xml('msPart/msContents/msItem/bibl', nil) # Bibliography
 end
 
 # We're being too clever here; the composed fields below are getting indexed into the sections_ssm field as serialized JSON hashes
@@ -227,6 +228,7 @@ compose 'parts_ssm', ->(record, accumulator, _context) { accumulator.concat reco
   to_field 'ms_alphabet_tesim', extract_xml('msPart/msContents/msItem/textLang', nil) #	Alfabeto	Alphabet
   to_field 'ms_colophon_tesim', extract_xml('msPart/msContents/msItem/colophon', nil) #	Colophon	Colophon
   to_field 'ms_secfol_tesim', extract_xml('msPart/msContents/msItem/writingSystem/secFol', nil) #	Secundum Folium	Secundum Folium
+  to_field 'ms_bibl_tesim', extract_xml('msPart/msContents/msItem/bibl', nil) # Bibliography
 end
 
 each_record do |_record, context|


### PR DESCRIPTION
…parts.

Closes #127 

Good exemplar TEI _(all in Pathway B):_
* Pal.lat.1564 (32 bibliographies)
* Reg.lat.1881 (2 bibliographies)
* Ross.604 (4 bibliographies)

_**Note:** There is only one bibliography per manuscript or part (I have not seen any multiples)_

## Manuscript
<img width="741" alt="ross_604-general" src="https://user-images.githubusercontent.com/96776/42051386-d0941aec-7ac0-11e8-8825-0ab274e6e520.png">


## Parts/Sections
<img width="625" alt="ross_604-parts" src="https://user-images.githubusercontent.com/96776/42051385-d07e57ca-7ac0-11e8-8e28-7871606c1270.png">

