### PR TITLE
Manuscript show page styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@ $logo-image: image-url('dvl_logo.png') !default;
 
 @import 'blacklight';
 @import 'spotlight';
+@import 'vatican_library_theme';
 @import 'modules/header';
 @import 'blocks/mirador_block';
 @import 'modules/metadata_details_btn';

--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -1,0 +1,14 @@
+#document {
+  h1 {
+    font-size: $font-size-h3;
+  }
+
+  h2 {
+    font-size: $font-size-h4;
+  }
+}
+
+.blacklight-catalog-show .dl-horizontal {
+  max-width: 90ch;
+  width: 100%;
+}

--- a/app/assets/stylesheets/modules/mixins.scss
+++ b/app/assets/stylesheets/modules/mixins.scss
@@ -1,0 +1,3 @@
+@mixin part-divider($property-name) {
+  #{$property-name}: 1px solid $navbar-inverse-link-color;
+}

--- a/app/assets/stylesheets/modules/parts_section.scss
+++ b/app/assets/stylesheets/modules/parts_section.scss
@@ -1,0 +1,41 @@
+.parts-section {
+  padding-left: 0;
+}
+
+.part {
+  @include part-divider(border-bottom);
+  padding: 0;
+
+  &:first-of-type {
+    @include part-divider(border-top);
+    margin-top: $padding-base-vertical;
+  }
+
+  h3 {
+    font-size: 1em;
+    margin-bottom: 0;
+    margin-top: $padding-base-vertical;
+  }
+
+  p {
+    margin-bottom: 0;
+  }
+
+  .btn-link {
+    float: right;
+    font-size: $font-size-h6;
+    padding: 0;
+  }
+
+  dl {
+    margin-top: $padding-large-vertical;
+  }
+}
+
+.part-header {
+  padding: 3px 0 6px;
+
+  .part-supplied-title {
+    font-style: italic;
+  }
+}

--- a/app/assets/stylesheets/vatican_library_theme.scss
+++ b/app/assets/stylesheets/vatican_library_theme.scss
@@ -1,0 +1,3 @@
+@import "modules/mixins";
+@import "modules/blacklight_overrides";
+@import "modules/parts_section";

--- a/app/views/catalog/_parts_default.html.erb
+++ b/app/views/catalog/_parts_default.html.erb
@@ -1,5 +1,5 @@
 <% if document.parts.any? %>
-  <div class="col-md-12">
+  <div class="col-md-12 parts-section">
     <h2><%= t('.title') %></h2>
     <% document.parts.each do |part| %>
       <div class="part col-md-12">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,8 +14,10 @@ en:
       title: Curatorial narrative
     parts_default:
       title: Parts of this manuscript
+    part_header_default:
+      view_details: View details
     show_manuscript:
-      general_title: General information
+      general_title: Manuscript information
       description_title: Description
       administrative_title: Administrative information
       hide_details: Fewer details

--- a/spec/features/manuscript_show_spec.rb
+++ b/spec/features/manuscript_show_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Manuscript display', type: :feature do
 
   it 'has a general information section' do
     visit spotlight.exhibit_solr_document_path(exhibit, 'Vat_gr_504')
-    expect(page).to have_css 'h2', text: 'General information'
+    expect(page).to have_css 'h2', text: 'Manuscript information'
 
     within '.general-section' do
       expect(page).to have_css 'dt', text: 'Shelfmark'


### PR DESCRIPTION
This is just a first-pass at the manuscript page. Mostly getting better proportioned font sizes for headings and styling the parts section so it's more compact and clean. I have some other improvements in-progress but will save for a later PR.

Here's what the bottom half of the page looks like with all parts closed:

<img width="507" alt="barb_gr_221_-_pathway-a_-_blacklight" src="https://user-images.githubusercontent.com/101482/42118808-4e14d934-7bbb-11e8-91ee-8ff2e87dd633.png">

---
And with a part open:

<img width="507" alt="part-open" src="https://user-images.githubusercontent.com/101482/42118687-f6d8007a-7bb9-11e8-9064-ced7ef5cae4f.png">

Note that I increased the width of the metadata `<dl>`s. We might have to revisit this after we see how the BAV curators end up doing their curatorial narratives. If they are short enough, I think we can just make the General info `<dl>` 50% and do the others as in this PR. If the narratives are long enough to go past the bottom of the General info section, then we might have to adjust.