### PR TITLE
Fixes an issue where multiple mirador configurations on the same page would corrupt eachother

### DIFF
--- a/app/assets/javascripts/mirador_messager.js
+++ b/app/assets/javascripts/mirador_messager.js
@@ -3,7 +3,7 @@ $(document).on('ready turbolinks:load', function() {
   $('[data-miradorfromscratch]').each(function(i, value) {
     
     // Setup Mirador to use config already existing in parent form
-    parent.$('#mirador-modal').on('shown.bs.modal', function (e) {
+    parent.$('[data-behavior="mirador-modal"]').on('shown.bs.modal', function (e) {
       var block = $(e.relatedTarget).data('block');
       var miradorConfig = JSON.parse(parent.$('#' + block).find('[name="mirador_config"]').val());
       var neededConfig = $.extend({

--- a/app/assets/javascripts/zpotlight/blocks/mirador_block.js
+++ b/app/assets/javascripts/zpotlight/blocks/mirador_block.js
@@ -60,7 +60,7 @@ SirTrevor.Blocks.Mirador = (function() {
     },
 
     modalTemplate: [
-      '<div id="mirador-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="#international modal">',
+      '<div id="<%= blockID %>-mirador-modal" class="modal fade" data-behavior="mirador-modal" tabindex="-1" role="dialog" aria-labelledby="#international modal">',
         '<div class="modal-dialog mirador-modal" role="document">',
           '<div class="modal-content">',
             '<div class="modal-header">',
@@ -89,7 +89,7 @@ SirTrevor.Blocks.Mirador = (function() {
             '<ol class=" dd-list" data-behavior="items-section"></ol>',
           '</div>',
           '<div class="col-md-3">',
-            '<a class="btn btn-primary configure-mirador-button" style="display: none;" data-toggle="modal" data-block="<%= blockID %>" data-target="#mirador-modal">Preview and Configure Viewer</a>',
+            '<a class="btn btn-primary configure-mirador-button" style="display: none;" data-toggle="modal" data-block="<%= blockID %>" data-target="#<%= blockID %>-mirador-modal">Preview and Configure Viewer</a>',
           '</div>',
         '</div>',
         '<div class="row">',

--- a/app/assets/javascripts/zpotlight/blocks/mirador_block.js
+++ b/app/assets/javascripts/zpotlight/blocks/mirador_block.js
@@ -60,11 +60,11 @@ SirTrevor.Blocks.Mirador = (function() {
     },
 
     modalTemplate: [
-      '<div id="<%= blockID %>-mirador-modal" class="modal fade" data-behavior="mirador-modal" tabindex="-1" role="dialog" aria-labelledby="#international modal">',
+      '<div id="<%= blockID %>-mirador-modal" class="modal fade" data-behavior="mirador-modal" tabindex="-1" role="dialog" aria-labelledby="#<%= blockID %>-modal-title">',
         '<div class="modal-dialog mirador-modal" role="document">',
           '<div class="modal-content">',
             '<div class="modal-header">',
-              '<h4 class="modal-title">Preview and Configure Mirador Viewer</h4>',
+              '<h4 class="modal-title" id="<%= blockID %>-modal-title">Preview and Configure Mirador Viewer</h4>',
             '</div>',
             '<div class="modal-body">',
               '<p>The Mirador Viewer will be displayed to exhibit visitors as shown below. Optionally, you can customize how the viewer will be displayed by adjusting one or more viewer options and saving the changes.</p>',

--- a/spec/features/mirador_widget_spec.rb
+++ b/spec/features/mirador_widget_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe 'Mirador Block', type: :feature, js: true do
 
       expect(hidden_input['value']).to eq mirador_config
 
-      find('[data-target="#mirador-modal"]', visible: false).click
+      find('.configure-mirador-button', visible: false).click
 
       expect(page).to have_css '.modal-body', visible: true # Modal is open
       within_frame 'miradorConfigFrame' do
@@ -244,7 +244,7 @@ RSpec.describe 'Mirador Block', type: :feature, js: true do
       end
       click_button 'Close'
 
-      find('[data-target="#mirador-modal"]', visible: false).click
+      find('.configure-mirador-button', visible: false).click
       within_frame 'miradorConfigFrame' do
         all('.mirador-viewer', visible: true) # Mirador is instantiated
       end


### PR DESCRIPTION
First reported in discussion with @jkeck . Now each modal has a unique `id` and the interactions should be scoped using that ID.