### PR TITLE
Select the correct instance of mirador when using multi-mirador on a

### DIFF
--- a/app/assets/javascripts/mirador_messager.js
+++ b/app/assets/javascripts/mirador_messager.js
@@ -1,13 +1,13 @@
 var miradorInstance;
 $(document).on('ready turbolinks:load', function() {
   $('[data-miradorfromscratch]').each(function(i, value) {
-    
+
     // Setup Mirador to use config already existing in parent form
     parent.$('[data-behavior="mirador-modal"]').on('shown.bs.modal', function (e) {
       var block = $(e.relatedTarget).data('block');
       var miradorConfig = JSON.parse(parent.$('#' + block).find('[name="mirador_config"]').val());
       var neededConfig = $.extend({
-        id: 'miradorId',
+        id: block + 'mirador_id',
         buildPath: '/assets/',
         i18nPath: '',
         imagesPath: ''

--- a/app/assets/javascripts/mirador_widget_admin.js
+++ b/app/assets/javascripts/mirador_widget_admin.js
@@ -29,7 +29,7 @@
     }
 
     function setupMiradorModalEvents(block) {
-      $('[data-save-mirador-config]').on('click', function(context) {
+      modalForBlock(block).find('[data-save-mirador-config]').on('click', function(context) {
         block.trigger('mirador-modal-closed', context);
       });
     }
@@ -52,8 +52,7 @@
     function modalMiradorSubmitListener(block) {
       block.on('mirador-modal-closed', function(e, value) {
         // Extract and merge config information
-        var blockId = block.data('mirador-block-id');
-        var $modal = $('#' + blockId + '-mirador-modal');
+        var $modal = modalForBlock(block);
         var miradorInstance = $modal.find('iframe')[0].contentWindow.miradorInstance;
         var config = miradorInstance.saveController.currentConfig;
         var newConfig = {
@@ -124,6 +123,10 @@
 
     function configureMiradorButton(block) {
       return block.find('.configure-mirador-button');
+    }
+
+    function modalForBlock(block) {
+      return $('#' + block.data('mirador-block-id') + '-mirador-modal');
     }
 
     function toggleSourceLocationFieldset(block) {

--- a/app/assets/javascripts/mirador_widget_admin.js
+++ b/app/assets/javascripts/mirador_widget_admin.js
@@ -53,8 +53,8 @@
       block.on('mirador-modal-closed', function(e, value) {
         // Extract and merge config information
         var blockId = block.data('mirador-block-id');
-        var miradorInstance = $(value.currentTarget).parents()
-          .find('iframe')[0].contentWindow.miradorInstance;
+        var $modal = $('#' + blockId + '-mirador-modal');
+        var miradorInstance = $modal.find('iframe')[0].contentWindow.miradorInstance;
         var config = miradorInstance.saveController.currentConfig;
         var newConfig = {
           data: config.data,
@@ -76,7 +76,7 @@
         block.find('[name="mirador_config"]').replaceWith(
           createMiradorConfigInput(newConfig)
         );
-        $('#' + blockId + '-mirador-modal').modal('hide')
+        $modal.modal('hide')
       })
     }
 

--- a/app/assets/javascripts/zpotlight/blocks/mirador_block.js
+++ b/app/assets/javascripts/zpotlight/blocks/mirador_block.js
@@ -72,7 +72,7 @@ SirTrevor.Blocks.Mirador = (function() {
             '</div>',
             '<div class="modal-body">',
               '<p>The Mirador Viewer will be displayed to exhibit visitors as shown below. Optionally, you can customize how the viewer will be displayed by adjusting one or more viewer options and saving the changes.</p>',
-              '<iframe id="miradorConfigFrame" src="<%= miradorPath() %>?options=buildFromScratch" height="100%" class="mirador-frame" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" width="100%"></iframe>',
+              '<iframe id="miradorConfigFrame" src="<%= miradorPath() %>?options=buildFromScratch&mirador_id=<%= blockID%>mirador_id" height="100%" class="mirador-frame" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" width="100%"></iframe>',
             '</div>',
             '<div class="modal-footer">',
               '<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>',

--- a/app/controllers/mirador_controller.rb
+++ b/app/controllers/mirador_controller.rb
@@ -12,5 +12,6 @@ class MiradorController < ApplicationController
     @manifest = params.fetch(:manifest, nil)
     @canvas = params.fetch(:canvas, nil)
     @options = params.fetch(:options, nil)
+    @mirador_id = params.fetch(:mirador_id, nil)
   end
 end

--- a/app/views/mirador/index.html.erb
+++ b/app/views/mirador/index.html.erb
@@ -3,7 +3,7 @@
 
 <% if @options == 'buildFromScratch' %>
   <%= content_tag :div, data: { miradorFromScratch: true } do %>
-    <%= content_tag :div, '', id: 'miradorId' %>
+    <%= content_tag :div, '', id: @mirador_id %>
   <% end %>
 <% else %>
 


### PR DESCRIPTION
page config

Fixes an issue where a multi-mirador setup isn't able to configure for the nth mirador