### PR TITLE
Add a ManuscriptMetadataPresenter to encapsulate the metadata section…

### DIFF
--- a/app/presenters/manuscript_metadata_presenter.rb
+++ b/app/presenters/manuscript_metadata_presenter.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+##
+# A simple presenter class that abstracts the logic of rendering sections of metadata
+# The sections are simple groupings of metadata based on configuration, and structured
+# in the UI with a heading and a definition list.
+class ManuscriptMetadataPresenter
+  def initialize(context:, document:)
+    @context = context
+    @document = document
+  end
+
+  def general_section
+    @general_section ||= Section.new(
+      context: context,
+      document: document,
+      type: :general
+    )
+  end
+
+  def description_section
+    @description_section ||= Section.new(
+      context: context,
+      document: document,
+      type: :description
+    )
+  end
+
+  def admin_section
+    @admin_section ||= Section.new(
+      context: context,
+      document: document,
+      type: :administrative
+    )
+  end
+
+  private
+
+  attr_reader :context, :document
+
+  ##
+  # A class to represent a section of metadata based on the provided type
+  class Section
+    delegate :document_show_fields,
+             :should_render_show_field?,
+             to: :context
+
+    attr_reader :context, :document
+    def initialize(context:, document:, type:)
+      @context = context
+      @document = document
+      @type = type.to_sym
+    end
+
+    def render?
+      fields.any?
+    end
+
+    def fields
+      document_show_fields(document).select do |_, field|
+        field.section == type && should_render_show_field?(document, field)
+      end
+    end
+
+    private
+
+    def type
+      return nil if @type == :description
+      @type
+    end
+  end
+end

--- a/app/views/catalog/_show_manuscript.html.erb
+++ b/app/views/catalog/_show_manuscript.html.erb
@@ -1,39 +1,42 @@
 <% doc_presenter = show_presenter(document) %>
-<div class="general-section row">
-  <h2 class="col-md-7"><%= t('.general_title') %></h2>
-  <%# default partial to display solr document fields in catalog show view -%>
-  <dl class="dl-horizontal dl-invert">
-    <% document_show_fields(document).select { |_, field| field.section == :general }.each do |field_name, field| -%>
-      <% if should_render_show_field? document, field %>
+<% metadata_presenter = ManuscriptMetadataPresenter.new(context: self, document: document) %>
+<% if metadata_presenter.general_section.render? %>
+  <div class="general-section row">
+    <h2 class="col-md-7"><%= t('.general_title') %></h2>
+    <dl class="dl-horizontal dl-invert">
+      <% metadata_presenter.general_section.fields.each do |field_name, field| -%>
   	    <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
   	    <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field_name %></dd>
       <% end -%>
-    <% end -%>
-  </dl>
-</div>
-<div id= "metadataDetails" class="description-section row" data-behavior="metadata-details">
-  <h2 class="col-md-7"><%= t('.description_title') %></h2>
-  <dl class="dl-horizontal dl-invert">
-    <% document_show_fields(document).select { |_, field| field.section.nil? }.each do |field_name, field| -%>
-      <% if should_render_show_field? document, field %>
-  	    <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
-  	    <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field_name %></dd>
-      <% end -%>
-    <% end -%>
-  </dl>
+    </dl>
+  </div>
+<% end %>
 
-  <h2 class="col-md-7"><%= t('.administrative_title') %></h2>
-  <dl class="dl-horizontal dl-invert">
-    <% document_show_fields(document).select { |_, field| field.section == :administrative }.each do |field_name, field| -%>
-      <% if should_render_show_field? document, field %>
-        <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
-        <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field_name %></dd>
-      <% end -%>
-    <% end -%>
-  </dl>
-</div>
-<button type='button' class='btn btn-sm btn-default btn-details hidden' data-toggle='collapse' data-target='#metadataDetails' aria-expanded='false' aria-controls='metadataDetails'>
-  <span class='btn-text-show'><%= t('.show_details') %></span>
-  <span class='btn-text-hide'><%= t('.hide_details') %></span>
-  <span class='btn-caret'>&raquo;</span>
-</button>
+<% if metadata_presenter.description_section.render? || metadata_presenter.admin_section.render? %>
+  <div id="metadataDetails" class="description-section row" data-behavior="metadata-details">
+    <% if metadata_presenter.description_section.render? %>
+      <h2 class="col-md-7"><%= t('.description_title') %></h2>
+      <dl class="dl-horizontal dl-invert">
+        <% metadata_presenter.description_section.fields.each do |field_name, field| -%>
+          <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
+          <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field_name %></dd>
+        <% end -%>
+      </dl>
+    <% end %>
+
+    <% if metadata_presenter.admin_section.render? %>
+      <h2 class="col-md-7"><%= t('.administrative_title') %></h2>
+      <dl class="dl-horizontal dl-invert">
+        <% metadata_presenter.admin_section.fields.each do |field_name, field| -%>
+          <dt class="blacklight-<%= field_name.parameterize %>"><%= render_document_show_field_label document, field: field_name %></dt>
+          <dd class="blacklight-<%= field_name.parameterize %>"><%= doc_presenter.field_value field_name %></dd>
+        <% end -%>
+      </dl>
+    <% end %>
+  </div>
+  <button type='button' class='btn btn-sm btn-default btn-details hidden' data-toggle='collapse' data-target='#metadataDetails' aria-expanded='false' aria-controls='metadataDetails'>
+    <span class='btn-text-show'><%= t('.show_details') %></span>
+    <span class='btn-text-hide'><%= t('.hide_details') %></span>
+    <span class='btn-caret'>&raquo;</span>
+  </button>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ module VaticanExhibits
       'ApiAuthorization::Unauthorized' => :unauthorized
     )
 
+    config.autoload_paths += %W(#{config.root}/app/presenters)
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/spec/presenters/manuscript_metadata_presenter_spec.rb
+++ b/spec/presenters/manuscript_metadata_presenter_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ManuscriptMetadataPresenter do
+  let(:presenter) { described_class.new(context: context, document: document) }
+
+  let(:context) do
+    instance_double(
+      'ViewContext',
+      document_show_fields: document_show_fields,
+      should_render_show_field?: should_render_show_field
+    )
+  end
+  let(:document) { SolrDocument.new }
+  let(:document_show_fields) { {} }
+  let(:should_render_show_field) { false }
+  let(:general_field) { instance_double('Field', section: :general) }
+  let(:description_field) { instance_double('Field', section: nil) }
+
+  describe 'section accessors' do
+    it 'has a general, description, and admin sections' do
+      expect(presenter.general_section).to be_a ManuscriptMetadataPresenter::Section
+      expect(presenter.description_section).to be_a ManuscriptMetadataPresenter::Section
+      expect(presenter.admin_section).to be_a ManuscriptMetadataPresenter::Section
+    end
+  end
+
+  describe ManuscriptMetadataPresenter::Section do
+    subject(:section) { described_class.new(context: context, document: document, type: type) }
+
+    let(:type) { :general }
+
+    describe '#render?' do
+      context 'when there are fields' do
+        let(:document_show_fields) { { field1: general_field } }
+        let(:should_render_show_field) { true }
+
+        it { expect(section.render?).to be true }
+      end
+
+      context 'when there are no fields' do
+        it { expect(section.render?).to be false }
+      end
+    end
+
+    describe '#fields' do
+      let(:document_show_fields) { { gen_field: general_field, desc_field: description_field } }
+
+      context 'when the description section' do
+        let(:type) { :description }
+        let(:should_render_show_field) { true }
+
+        it 'is an array of the fields w/o a section' do
+          expect(section.fields.values.length).to eq 1
+          expect(section.fields.values.first.section).to be_nil
+        end
+      end
+
+      context 'when another section' do
+        let(:should_render_show_field) { true }
+
+        it 'is an array of fields based on the given section' do
+          expect(section.fields.values.length).to eq 1
+          expect(section.fields.values.first.section).to eq :general
+        end
+      end
+
+      describe 'when the field is not configured to display' do
+        it 'is not returned' do
+          expect(section.fields).to be_blank
+        end
+      end
+    end
+
+    context 'when type is description' do
+      let(:type) { :description }
+
+      it 'has a type of nil (since it is the default section)' do
+        expect(section.send(:type)).to be_nil
+      end
+    end
+
+    context 'when type is not description' do
+      it 'is the passed in type' do
+        expect(section.send(:type)).to be :general
+      end
+    end
+  end
+end


### PR DESCRIPTION
… rendering logic.

Closes #197 

## Example (Vat_gr_984 in `palimpsests`)

### Before
<img width="822" alt="vat_gr_984-before" src="https://user-images.githubusercontent.com/96776/42246972-9988499e-7ed3-11e8-8c97-d0e606042ba2.png">

### After
<img width="930" alt="vat_gr_984-after" src="https://user-images.githubusercontent.com/96776/42246973-999d6ef0-7ed3-11e8-9911-227b8625e91f.png">
