### PR TITLE
View details collapse improvements

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,7 @@ $logo-image: image-url('dvl_logo.png') !default;
 @import 'modules/header';
 @import 'blocks/mirador_block';
 @import 'modules/metadata_details_btn';
+@import 'modules/collapse';
 
 .mirador-embed-wrapper {
   height: 60vh;

--- a/app/assets/stylesheets/modules/collapse.scss
+++ b/app/assets/stylesheets/modules/collapse.scss
@@ -1,0 +1,9 @@
+[data-toggle="collapse"] {
+  &.collapsed .collapse-shown {
+    display: none;
+  }
+
+  &:not(.collapsed) .collapse-hidden {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/modules/metadata_details_btn.scss
+++ b/app/assets/stylesheets/modules/metadata_details_btn.scss
@@ -5,25 +5,9 @@
     transform: rotate(-90deg);
   }
 
-  .btn-text-hide {
-    display: inline;
-  }
-
-  .btn-text-show {
-    display: none;
-  }
-
   &.collapsed {
     .btn-caret {
       transform: rotate(90deg);
-    }
-
-    .btn-text-show {
-      display: inline;
-    }
-
-    .btn-text-hide {
-      display: none;
     }
   }
 }

--- a/app/assets/stylesheets/modules/parts_section.scss
+++ b/app/assets/stylesheets/modules/parts_section.scss
@@ -1,15 +1,5 @@
 .parts-section {
   padding-left: 0;
-
-  [data-toggle="collapse"] {
-    &.collapsed .area-not-collapsed {
-      display: none;
-    }
-
-    &:not(.collapsed) .area-collapsed {
-      display: none;
-    }
-  }
 }
 
 .part {

--- a/app/assets/stylesheets/modules/parts_section.scss
+++ b/app/assets/stylesheets/modules/parts_section.scss
@@ -1,5 +1,15 @@
 .parts-section {
   padding-left: 0;
+
+  [data-toggle="collapse"] {
+    &.collapsed .area-not-collapsed {
+      display: none;
+    }
+
+    &:not(.collapsed) .area-collapsed {
+      display: none;
+    }
+  }
 }
 
 .part {

--- a/app/views/catalog/_part_header_default.html.erb
+++ b/app/views/catalog/_part_header_default.html.erb
@@ -7,8 +7,13 @@
       <span class="part-author-date"><%= show_presenter.field_value('ms_author_date_tesim') %>.</span>
     <% end %>
     <span class="part-supplied-title"><%= show_presenter.field_value('ms_supplied_title_tesim') %></span>
-    <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#part-show-<%= document.first('ms_locus_tesim').parameterize %>" aria-expanded="false" aria-controls="part-show-<%= document.first('ms_locus_tesim').parameterize %>">
-      <%= t('.view_details') %>
+    <button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#part-show-<%= document.first('ms_locus_tesim').parameterize %>" aria-expanded="false" aria-controls="part-show-<%= document.first('ms_locus_tesim').parameterize %>">
+      <span class="area-not-collapsed">
+        <%= t('.hide_details') %>
+      </span>
+      <span class="area-collapsed">
+        <%= t('.view_details') %>
+      </span>
     </button>
   </p>
 </div>

--- a/app/views/catalog/_part_header_default.html.erb
+++ b/app/views/catalog/_part_header_default.html.erb
@@ -8,10 +8,10 @@
     <% end %>
     <span class="part-supplied-title"><%= show_presenter.field_value('ms_supplied_title_tesim') %></span>
     <button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#part-show-<%= document.first('ms_locus_tesim').parameterize %>" aria-expanded="false" aria-controls="part-show-<%= document.first('ms_locus_tesim').parameterize %>">
-      <span class="area-not-collapsed">
+      <span class="collapse-shown">
         <%= t('.hide_details') %>
       </span>
-      <span class="area-collapsed">
+      <span class="collapse-hidden">
         <%= t('.view_details') %>
       </span>
     </button>

--- a/app/views/catalog/_part_show_default.html.erb
+++ b/app/views/catalog/_part_show_default.html.erb
@@ -1,3 +1,3 @@
-<div id="part-show-<%= document.first('ms_locus_tesim').parameterize %>" class="collapse">
+<div id="part-show-<%= document.first('ms_locus_tesim').parameterize %>" class="collapse clearfix">
   <%= render_document_partial document, :show %>
 </div>

--- a/app/views/catalog/_show_manuscript.html.erb
+++ b/app/views/catalog/_show_manuscript.html.erb
@@ -35,8 +35,8 @@
     <% end %>
   </div>
   <button type='button' class='btn btn-sm btn-default btn-details hidden' data-toggle='collapse' data-target='#metadataDetails' aria-expanded='false' aria-controls='metadataDetails'>
-    <span class='btn-text-show'><%= t('.show_details') %></span>
-    <span class='btn-text-hide'><%= t('.hide_details') %></span>
+    <span class='collapse-hidden'><%= t('.show_details') %></span>
+    <span class='collapse-shown'><%= t('.hide_details') %></span>
     <span class='btn-caret'>&raquo;</span>
   </button>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
     parts_default:
       title: Parts of this manuscript
     part_header_default:
+      hide_details: Hide details
       view_details: View details
     show_manuscript:
       general_title: Manuscript information

--- a/spec/features/manuscript_show_spec.rb
+++ b/spec/features/manuscript_show_spec.rb
@@ -31,4 +31,12 @@ RSpec.describe 'Manuscript display', type: :feature do
     expect(page).to have_css 'dt', text: 'Author'
     expect(page).to have_css 'dd', text: 'Gregorius Nazianzenu'
   end
+
+  it 'has collapsible parts', js: true do
+    visit spotlight.exhibit_solr_document_path(exhibit, 'Vat_gr_504')
+    expect(page).to have_css '.blacklight-ms_author_tesim', text: 'Gregorius Nazianzenus,', visible: false
+    all('button', text: 'View details')[0].click
+    expect(page).to have_css '.blacklight-ms_author_tesim', text: 'Gregorius Nazianzenus,', visible: true
+    expect(page).to have_css 'button', text: 'Hide details', visible: true
+  end
 end


### PR DESCRIPTION
Fixes #196 

The view/hide is a css only fix. While the immediate close issue was due to a height not being able to be calculated (upstream references in #196)

![view details](https://user-images.githubusercontent.com/1656824/42346318-86960d34-805f-11e8-9118-1d3b6ed9d087.gif)
