### PR TITLE
Hide warning message for curatorial narrative field

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,7 @@ $logo-image: image-url('dvl_logo.png') !default;
 .mirador-embed-wrapper {
   height: 60vh;
 }
+
+#solr_document_sidecar_data_curatorial_narrative_tesim + .help-block {
+  display: none;
+}


### PR DESCRIPTION
Fixes #230 
This PR removes the warning message for the `Curatorial narrative` field. This field is configured to be published by default, so the warning message is irrelevant. 

## Before
![warning msg](https://user-images.githubusercontent.com/5402927/42528546-a89dbda8-8430-11e8-9e56-b53377dafde5.png)

## After
![warning msg hidden](https://user-images.githubusercontent.com/5402927/42528545-a87824e4-8430-11e8-80b6-48eeaeb73469.png)