### PR TITLE
restrict mirador autocomplete to manuscript objects only

### DIFF
--- a/app/assets/javascripts/zpotlight/blocks/mirador_block.js
+++ b/app/assets/javascripts/zpotlight/blocks/mirador_block.js
@@ -8,7 +8,12 @@ SirTrevor.Blocks.Mirador = (function() {
      * autocomplete_url, autocomplete_template, and transform_autocomplete_results
      * were copied from https://github.com/projectblacklight/spotlight/blob/master/app/assets/javascripts/spotlight/blocks/solr_documents_base_block.js
      */
-    autocomplete_url: function() { return this.$instance().closest('form[data-autocomplete-exhibit-catalog-path]').data('autocomplete-exhibit-catalog-path').replace("%25QUERY", "%QUERY"); },
+    autocomplete_url: function() {
+      return this.$instance()
+                 .closest('form[data-autocomplete-exhibit-catalog-path]')
+                 .data('autocomplete-exhibit-catalog-path')
+                 .replace("%25QUERY", "%QUERY") + '&f[resource_type_ssim][]=Manuscript';
+    },
     autocomplete_template: function() { return '<div class="autocomplete-item{{#if private}} blacklight-private{{/if}}">{{#if thumbnail}}<div class="document-thumbnail thumbnail"><img src="{{thumbnail}}" /></div>{{/if}}<span class="autocomplete-title">{{title}}</span><br/><small>&nbsp;&nbsp;{{description}}</small></div>' },
     transform_autocomplete_results: function(response) {
       return $.map(response['docs'], function(doc) {


### PR DESCRIPTION
Fixes #233 