### PR TITLE
Sets up Mirador to show annotations when a canvas is passed through

### DIFF
--- a/app/assets/javascripts/mirador_bundle.js
+++ b/app/assets/javascripts/mirador_bundle.js
@@ -1,2 +1,3 @@
 //= require mirador
 //= require mirador_messager
+//= require annotot/annotot_endpoint

--- a/app/assets/stylesheets/mirador_bundle.scss
+++ b/app/assets/stylesheets/mirador_bundle.scss
@@ -1,3 +1,9 @@
 @import 'font-awesome';
 @import 'material_icons';
 @import 'mirador-combined';
+
+// There is no setting to show/hide edit and delete controls, thus we just need
+// display:none as editing capabilities is not needed for this application.
+.mirador-container .annotation-display.annotation-tooltip .button-container {
+  display: none;
+}

--- a/app/helpers/mirador_helper.rb
+++ b/app/helpers/mirador_helper.rb
@@ -23,10 +23,18 @@ module MiradorHelper
         "canvasControls": {
           "annotations": {
             "annotationLayer": true,
-            "annotationState": 'on'
+            "annotationState": canvas ? 'on' : 'off', # set the annotationState on whether or not a canvas is passed
+            "annotationCreation": false
           }
         }
-      }]
+      }],
+      "annotationEndpoint": {
+        name: 'Annotot',
+        module: 'AnnototEndpoint',
+        options: {
+          endpoint: annotot_path
+        }
+      }
     }
   end
   # rubocop:enable MethodLength

--- a/spec/helpers/mirador_helper_spec.rb
+++ b/spec/helpers/mirador_helper_spec.rb
@@ -14,5 +14,28 @@ RSpec.describe MiradorHelper, type: :helper do
       expect(mirador_options[:windowObjects].first[:loadedManifest]).to be manifest
       expect(mirador_options[:windowObjects].first[:canvasID]).to be canvas
     end
+    context 'with no canvas' do
+      it 'turns off annotationState' do
+        mirador_options = mirador_options(manifest, nil)
+        expect(
+          mirador_options[:windowObjects].first[:canvasControls][:annotations][:annotationState]
+        ).to eq 'off'
+      end
+    end
+
+    context 'with canvas' do
+      it 'turns on annotationState' do
+        mirador_options = mirador_options(manifest, canvas)
+        expect(
+          mirador_options[:windowObjects].first[:canvasControls][:annotations][:annotationState]
+        ).to eq 'on'
+      end
+    end
+
+    it 'configures AnnototEndpoint' do
+      mirador_options = mirador_options(manifest, nil)
+      expect(mirador_options[:annotationEndpoint][:module]).to eq 'AnnototEndpoint'
+      expect(mirador_options[:annotationEndpoint][:options][:endpoint]).to eq '/annotations'
+    end
   end
 end


### PR DESCRIPTION
This logic mimicks a show page for an annotationList

Fixes #256 

![annoshowpage](https://user-images.githubusercontent.com/1656824/42711346-c4d3bbc8-86a4-11e8-8263-721d561e90a0.gif)
