### PR TITLE
Update styling and layout of brandbar and landing page cards

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -56,6 +56,10 @@ body {
   padding: $padding-base-vertical 0;
 }
 
+#per_page-dropdown .dropdown-toggle {
+  color: $default-link-color;
+}
+
 .breadcrumb {
   border-bottom: 1px solid $navbar-inverse-link-color;
   border-radius: 0;

--- a/app/assets/stylesheets/modules/header.scss
+++ b/app/assets/stylesheets/modules/header.scss
@@ -1,9 +1,12 @@
 #header-navbar {
+  min-height: 40px;
+
   .navbar-brand {
-    height: 56px;
+    background-position: 18px 4px;
+    background-size: auto 40px;
   }
 
   .nav > li > a {
-    padding: 15px 15px 3px;
+    padding: 15px 12px;
   }
 }

--- a/app/assets/stylesheets/modules/site_home.scss
+++ b/app/assets/stylesheets/modules/site_home.scss
@@ -10,6 +10,19 @@
   }
 }
 
+.card-face,
+.card-back {
+  background-color: $vatican-blue-lighter;
+}
+
+.card-face {
+  border-color: darken($vatican-blue-lighter, 10%);
+
+  img {
+    border-bottom: 1px solid darken($vatican-blue-lighter, 10%);
+  }
+}
+
 // Adjustments to site home sidebar
 .home-page-column {
   margin-left: 6px;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -3,6 +3,7 @@
 // Vatican Variables
 $vatican-blue: #1c315b;
 $vatican-blue-alternate: #286090;
+$vatican-blue-lighter: rgba(28, 49, 91, .1);
 
 $base-background-color: #f7f7f7;
 


### PR DESCRIPTION
A few minor styling updates:

* Make the search results per-page dropdown link match the link color used elsewhere on the site
* Adjust layout of the brandbar to reduce height a bit and make the dropdown menus line up better (A in screenshot below)
* Adjust color of site landing page cards to match the Vatican theme a bit better (B in screenshot below)

<img width="605" alt="thematic_pathways_of_medieval_manuscripts" src="https://user-images.githubusercontent.com/101482/42902404-6d06addc-8a83-11e8-8e3b-4df032e4a841.png">
