### PR TITLE
Protect from forgery by default

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module VaticanExhibits
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-    
+
     config.action_dispatch.rescue_responses.merge!(
       'ApiAuthorization::Unauthorized' => :unauthorized
     )
@@ -35,6 +35,9 @@ module VaticanExhibits
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # Protect from forgery by default
+    config.action_controller.protect_from_forgery
 
     config.middleware.insert_before 0, Rack::Cors do
       allow do


### PR DESCRIPTION
Rails 5.2 added this behavior in rails/rails#29742

Fixes #272
