### PR TITLE
Add Italian translations for user-facing strings

### DIFF
--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,4 +1,26 @@
 it:
+  footer:
+    copyright_heading: Copyright © Vatican Library
+    copyright_text: Tutti i diritti riservati. I contenuti di questo sito sono protetti da copyright. Né il testo né le immagini possono essere riprodotti, in alcuna forma, senza l'autorizzazione della Biblioteca Vaticana, V-00120, Città del Vaticano.
+    partnership_heading: In partecipazione con
+    project_support_heading: Progetto finanziato da
+    project_support_text: La Fondazoine Andrew W. Mellon
+  catalog:
+    annotations_annotation:
+      title: Altre annotazioni in questo foglio
+    curatorial_narrative_default:
+      title: Testo del curatore
+    parts_default:
+      title: Descrizioni interne
+    part_header_default:
+      hide_details: Nascondi i dettagli
+      view_details: Visualizza i dettagli
+    show_manuscript:
+      general_title: Informazioni sul manoscritto
+      description_title: Descrizione
+      administrative_title: Informazioni amministrative
+      hide_details: Meno dettagli
+      show_details: Più dettagli
   blacklight:
     search:
       fields:


### PR DESCRIPTION
Closes #149 

Adds Italian translations for user-facing strings added by Vatican-specific features, such as the footer and the headings and button labels on the manuscript show page (the "Copyright @ Vatican Library" string intentionally not translated):

![vat_gr_218_-_curator_-_thematic_pathways_of_medieval_manuscripts](https://user-images.githubusercontent.com/101482/43427074-e71bb602-940c-11e8-8bbe-cc0e2b9ab03a.png)

---
![curator_-_thematic_pathways_of_medieval_manuscripts](https://user-images.githubusercontent.com/101482/43427078-ec4d126a-940c-11e8-8c3c-cd020ba4c2e7.png)
