### PR TITLE
Special name display

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -101,8 +101,8 @@ class CatalogController < ApplicationController
     config.add_show_field 'ms_watermarks_tesim'
     config.add_show_field 'ms_motto_tesim'
     config.add_show_field 'ms_locus_tesim'
-    config.add_show_field 'ms_author_tesim'
-    config.add_show_field 'ms_other_author_tesim'
+    config.add_show_field 'ms_author_tesim', separator_options: { words_connector: '<br>' }
+    config.add_show_field 'ms_other_author_tesim', separator_options: { words_connector: '<br>' }
     config.add_show_field 'ms_title_tesim'
     config.add_show_field 'ms_supplied_title_tesim'
     config.add_show_field 'ms_uniform_title_tesim'
@@ -119,7 +119,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'ms_type_of_document_tesim'
     config.add_show_field 'ms_general_note_tesim'
     config.add_show_field 'ms_source_note_tesim'
-    config.add_show_field 'ms_other_name_tesim'
+    config.add_show_field 'ms_other_name_tesim', separator_options: { words_connector: '<br>' }
     config.add_show_field 'ms_subject_tesim'
     config.add_show_field 'ms_language_ssim', link_to_search: true
     config.add_show_field 'ms_alphabet_ssim', link_to_search: true

--- a/lib/name_display.rb
+++ b/lib/name_display.rb
@@ -1,0 +1,32 @@
+##
+# A class used to create a special display from an XML element of Vatican
+# flavored TEI
+class NameDisplay
+  attr_reader :author
+
+  delegate :text, to: :author
+
+  def initialize(author)
+    @author = author
+  end
+
+  def title
+    author.attribute('title')&.value
+  end
+
+  def date
+    author.attribute('date')&.value
+  end
+
+  def formal
+    author.attribute('formal')&.value
+  end
+
+  def type
+    "[#{author.attribute('type').value}]" if author.attribute('type')
+  end
+
+  def display
+    [text, title, date, formal, type].compact.join(' ')
+  end
+end

--- a/lib/traject/vatican_iiif_config.rb
+++ b/lib/traject/vatican_iiif_config.rb
@@ -1,4 +1,5 @@
 require 'traject_plus/macros'
+require 'name_display'
 
 # rubocop:disable Style/MixinUsage
 extend TrajectPlus::Macros
@@ -40,18 +41,27 @@ compose ->(record, accumulator, _context) { accumulator << record.tei.xpath('//T
   to_field 'dated_mss_ssim', extract_xml(
     'origDate/@n', nil
   )
-  to_field 'author_ssim', extract_xml(
-    "author/alias/authorityAuthor[@rif='aut']", nil,
-    gsub: [/[,\.]$/, '']
-  )
-  to_field 'other_author_ssim', extract_xml(
-    "name[@role='internal' or @role='external']/alias/authorityAuthor[@rif='aut']", nil,
-    gsub: [/[,\.]$/, '']
-  )
-  to_field 'other_name_ssim', extract_xml(
-    "name[@role!='internal' and @role!='external' or not(@role)]/alias/authorityAuthor[@rif='aut']", nil,
-    gsub: [/[,\.]$/, '']
-  )
+  to_field 'author_ssim', (accumulate do |resource, *_|
+    resource.xpath("author/alias/authorityAuthor[@rif='aut']").map do |author|
+      NameDisplay.new(
+        author
+      ).display
+    end
+  end)
+  to_field 'other_author_ssim', (accumulate do |resource, *_|
+    resource.xpath("name[@role='internal' or @role='external']/alias/authorityAuthor[@rif='aut']").map do |author|
+      NameDisplay.new(
+        author
+      ).display
+    end
+  end)
+  to_field 'other_name_ssim', (accumulate do |resource, *_|
+    resource.xpath("name[@role!='internal' and @role!='external' or not(@role)]/alias/authorityAuthor[@rif='aut']").map do |author|
+      NameDisplay.new(
+        author
+      ).display
+    end
+  end)
   to_field 'other_name_and_role_ssim', (accumulate do |resource, *_|
     resource.xpath("name[@role!='internal' and @role!='external' or not(@role)]").flat_map do |name|
       name.xpath("alias/authorityAuthor[@rif='aut']").map do |author|
@@ -169,9 +179,21 @@ compose ->(record, accumulator, _context) { accumulator << record.tei.xpath('//T
   to_field 'ms_watermarks_tesim', extract_xml('msPart/head/watermarks/p', nil) #	Filigrane	Watermarks
   to_field 'ms_motto_tesim', extract_xml('msPart/head/motto', nil) #	Motto	Motto
   to_field 'ms_locus_tesim', extract_xml('msPart/msContents/msItem/locus', nil) #	Locus	Locus
-  to_field 'ms_author_tesim', extract_xml('msPart/msContents/msItem/author/alias/authorityAuthor[@rif="aut"]', nil) #	Autore	Author
+  to_field 'ms_author_tesim', (accumulate do |resource, *_| #	Autore	Author
+    resource.xpath('msPart/msContents/msItem/author/alias/authorityAuthor[@rif="aut"]').map do |author|
+      NameDisplay.new(
+        author
+      ).display
+    end
+  end)
   to_field 'ms_author_date_tesim', extract_xml('msPart/msContents/msItem/author/alias/authorityAuthor[@rif="aut"]/@date', nil)
-  to_field 'ms_other_author_tesim', extract_xml('msPart/msContents/msItem/name[@role="internal" or @role="external"]/alias/authorityAuthor[@rif="aut"]', nil) #	Altro autore	Other author
+  to_field 'ms_other_author_tesim', (accumulate do |resource, *_| #	Altro autore	Other author
+    resource.xpath('msPart/msContents/msItem/name[@role="internal" or @role="external"]/alias/authorityAuthor[@rif="aut"]').map do |author|
+      NameDisplay.new(
+        author
+      ).display
+    end
+  end)
   to_field 'ms_title_tesim', extract_xml('msPart/msContents/msItem/title[@type="title"]/@value', nil) #		Titolo	Title
   to_field 'ms_supplied_title_tesim', extract_xml('msPart/msContents/msItem/title[@type="supplied"]/@value', nil) #		Titolo supplito	Supplied title
   to_field 'ms_uniform_title_tesim', extract_xml('msPart/msContents/msItem/uniformTitle/alias/authorityTitleSeries[@rif="aut"]/@value', nil) #		Titolo uniforme	Uniform title
@@ -188,7 +210,13 @@ compose ->(record, accumulator, _context) { accumulator << record.tei.xpath('//T
   to_field 'ms_type_of_document_tesim', extract_xml('msPart/msContents/msItem/note[@anchored and not(@anchored="yes")]', nil) #	Tipologia documento	Type of document
   to_field 'ms_general_note_tesim', extract_xml('msPart/msContents/msItem/note[@anchored="yes" or not(@anchored)]', nil) #	Nota	General note
   to_field 'ms_source_note_tesim', extract_xml('msPart/msContents/msItem/note[@anchored="sourceSYS"]', nil) #		Nota di fonte	Source note
-  to_field 'ms_other_name_tesim', extract_xml('msPart/msContents/msItem/name[@role!="internal" and @role!="external" or not(@role)]/alias/authorityAuthor[@rif="aut"]', nil) #	Altro nome	Other name
+  to_field 'ms_other_name_tesim', (accumulate do |resource, *_| #	Altro nome	Other name
+    resource.xpath('msPart/msContents/msItem/name[@role!="internal" and @role!="external" or not(@role)]/alias/authorityAuthor[@rif="aut"]').map do |author|
+      NameDisplay.new(
+        author
+      ).display
+    end
+  end)
   to_field 'ms_subject_tesim', extract_xml('msPart/msContents/msItem/keywords/term/alias/authoritySubject[@rif="aut"]', nil) #	Soggetto	Subject
   to_field 'ms_language_ssim', extract_xml('msPart/msContents/msItem/textLang', nil) #	Lingua	Language
   to_field 'ms_alphabet_ssim', extract_xml('msPart/msContents/msItem/textLang/@n', nil) #	Alfabeto	Alphabet

--- a/spec/fixtures/manifests/MSS_Ott.gr.85.json
+++ b/spec/fixtures/manifests/MSS_Ott.gr.85.json
@@ -1,0 +1,15582 @@
+{
+  "@context" : "http://iiif.io/api/presentation/2/context.json",
+  "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/manifest.json",
+  "@type" : "sc:Manifest",
+  "metadata" : [ {
+    "label" : "Shelfmark",
+    "value" : "Ott.gr.85"
+  }, {
+    "label" : "Title",
+    "value" : [ "Miscellanea homiletica" ]
+  }, {
+    "label" : "Date",
+    "value" : [ "sec. X-XI" ]
+  }, {
+    "label" : "Contributor",
+    "value" : "<a href='http://bav.bodleian.ox.ac.uk/' target='_blank'>Polonsky Foundation Digitization Project</a>"
+  } ],
+  "label" : "Ott.gr.85",
+  "description" : "",
+  "thumbnail" : {
+    "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/cover/cover.jpg",
+    "@type" : "dctypes:Image",
+    "format" : "image/jpeg"
+  },
+  "viewingDirection" : "left-to-right",
+  "viewingHint" : "paged",
+  "attribution" : "Images Copyright Biblioteca Apostolica Vaticana",
+  "logo" : "https://digi.vatlib.it/resource/img/i/DVL_logo.jpg",
+  "sequences" : [ {
+    "@type" : "sc:Sequence",
+    "canvases" : [ {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0001",
+      "@type" : "sc:Canvas",
+      "label" : "piatto.anteriore",
+      "width" : 2145,
+      "height" : 2920,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0001",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0001",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0001_al_piatto.anteriore.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2145,
+          "height" : 2920
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0001"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0001_al_piatto.anteriore.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 110,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0002",
+      "@type" : "sc:Canvas",
+      "label" : "risguardia.anteriore",
+      "width" : 2040,
+      "height" : 2918,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0002",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0002",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0002_ba_risguardia.anteriore.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2040,
+          "height" : 2918
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0002"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0002_ba_risguardia.anteriore.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0003",
+      "@type" : "sc:Canvas",
+      "label" : "1r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0003",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0003",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0003_cy_0001r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0003"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0003_cy_0001r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0004",
+      "@type" : "sc:Canvas",
+      "label" : "1v",
+      "width" : 1995,
+      "height" : 2790,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0004",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0004",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0004_cy_0001v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1995,
+          "height" : 2790
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0004"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0004_cy_0001v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0005",
+      "@type" : "sc:Canvas",
+      "label" : "Ir",
+      "width" : 1855,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0005",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0005",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0005_cr_0001r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1855,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0005"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0005_cr_0001r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0006",
+      "@type" : "sc:Canvas",
+      "label" : "Iv",
+      "width" : 1875,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0006",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0006",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0006_cr_0001v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1875,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0006"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0006_cr_0001v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0007",
+      "@type" : "sc:Canvas",
+      "label" : "IIr",
+      "width" : 1780,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0007",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0007",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0007_cr_0002r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1780,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0007"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0007_cr_0002r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0008",
+      "@type" : "sc:Canvas",
+      "label" : "IIv",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0008",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0008",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0008_cr_0002v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0008"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0008_cr_0002v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0009",
+      "@type" : "sc:Canvas",
+      "label" : "1r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0009",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0009",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0009_fa_0001r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0009"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0009_fa_0001r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0010",
+      "@type" : "sc:Canvas",
+      "label" : "1v",
+      "width" : 1845,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0010",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0010",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0010_fa_0001v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1845,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0010"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0010_fa_0001v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0011",
+      "@type" : "sc:Canvas",
+      "label" : "2r",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0011",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0011",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0011_fa_0002r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0011"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0011_fa_0002r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0012",
+      "@type" : "sc:Canvas",
+      "label" : "2v",
+      "width" : 1840,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0012",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0012",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0012_fa_0002v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1840,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0012"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0012_fa_0002v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0013",
+      "@type" : "sc:Canvas",
+      "label" : "3r",
+      "width" : 1800,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0013",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0013",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0013_fa_0003r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1800,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0013"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0013_fa_0003r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0014",
+      "@type" : "sc:Canvas",
+      "label" : "3v",
+      "width" : 1855,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0014",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0014",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0014_fa_0003v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1855,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0014"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0014_fa_0003v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0015",
+      "@type" : "sc:Canvas",
+      "label" : "4r",
+      "width" : 1810,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0015",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0015",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0015_fa_0004r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1810,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0015"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0015_fa_0004r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0016",
+      "@type" : "sc:Canvas",
+      "label" : "4v",
+      "width" : 1875,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0016",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0016",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0016_fa_0004v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1875,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0016"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0016_fa_0004v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0017",
+      "@type" : "sc:Canvas",
+      "label" : "5r",
+      "width" : 1810,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0017",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0017",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0017_fa_0005r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1810,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0017"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0017_fa_0005r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0018",
+      "@type" : "sc:Canvas",
+      "label" : "5v",
+      "width" : 1875,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0018",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0018",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0018_fa_0005v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1875,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0018"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0018_fa_0005v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0019",
+      "@type" : "sc:Canvas",
+      "label" : "6r",
+      "width" : 1810,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0019",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0019",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0019_fa_0006r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1810,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0019"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0019_fa_0006r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0020",
+      "@type" : "sc:Canvas",
+      "label" : "6v",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0020",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0020",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0020_fa_0006v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0020"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0020_fa_0006v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0021",
+      "@type" : "sc:Canvas",
+      "label" : "7r",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0021",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0021",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0021_fa_0007r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0021"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0021_fa_0007r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0022",
+      "@type" : "sc:Canvas",
+      "label" : "7v",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0022",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0022",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0022_fa_0007v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0022"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0022_fa_0007v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0023",
+      "@type" : "sc:Canvas",
+      "label" : "8r",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0023",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0023",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0023_fa_0008r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0023"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0023_fa_0008r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0024",
+      "@type" : "sc:Canvas",
+      "label" : "8v",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0024",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0024",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0024_fa_0008v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0024"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0024_fa_0008v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0025",
+      "@type" : "sc:Canvas",
+      "label" : "9r",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0025",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0025",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0025_fa_0009r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0025"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0025_fa_0009r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0026",
+      "@type" : "sc:Canvas",
+      "label" : "9v",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0026",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0026",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0026_fa_0009v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0026"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0026_fa_0009v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0027",
+      "@type" : "sc:Canvas",
+      "label" : "10r",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0027",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0027",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0027_fa_0010r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0027"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0027_fa_0010r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0028",
+      "@type" : "sc:Canvas",
+      "label" : "10v",
+      "width" : 1855,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0028",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0028",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0028_fa_0010v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1855,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0028"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0028_fa_0010v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0029",
+      "@type" : "sc:Canvas",
+      "label" : "11r",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0029",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0029",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0029_fa_0011r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0029"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0029_fa_0011r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0030",
+      "@type" : "sc:Canvas",
+      "label" : "11v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0030",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0030",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0030_fa_0011v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0030"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0030_fa_0011v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0031",
+      "@type" : "sc:Canvas",
+      "label" : "12r",
+      "width" : 1755,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0031",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0031",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0031_fa_0012r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1755,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0031"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0031_fa_0012r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0032",
+      "@type" : "sc:Canvas",
+      "label" : "12v",
+      "width" : 1855,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0032",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0032",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0032_fa_0012v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1855,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0032"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0032_fa_0012v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0033",
+      "@type" : "sc:Canvas",
+      "label" : "13r",
+      "width" : 1750,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0033",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0033",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0033_fa_0013r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1750,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0033"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0033_fa_0013r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0034",
+      "@type" : "sc:Canvas",
+      "label" : "13v",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0034",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0034",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0034_fa_0013v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0034"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0034_fa_0013v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0035",
+      "@type" : "sc:Canvas",
+      "label" : "14r",
+      "width" : 1750,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0035",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0035",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0035_fa_0014r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1750,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0035"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0035_fa_0014r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0036",
+      "@type" : "sc:Canvas",
+      "label" : "14v",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0036",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0036",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0036_fa_0014v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0036"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0036_fa_0014v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0037",
+      "@type" : "sc:Canvas",
+      "label" : "15r",
+      "width" : 1730,
+      "height" : 2771,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0037",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0037",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0037_fa_0015r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1730,
+          "height" : 2771
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0037"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0037_fa_0015r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 93,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0038",
+      "@type" : "sc:Canvas",
+      "label" : "15v",
+      "width" : 1845,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0038",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0038",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0038_fa_0015v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1845,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0038"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0038_fa_0015v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0039",
+      "@type" : "sc:Canvas",
+      "label" : "16r",
+      "width" : 1745,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0039",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0039",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0039_fa_0016r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1745,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0039"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0039_fa_0016r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0040",
+      "@type" : "sc:Canvas",
+      "label" : "16v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0040",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0040",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0040_fa_0016v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0040"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0040_fa_0016v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0041",
+      "@type" : "sc:Canvas",
+      "label" : "17r",
+      "width" : 1745,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0041",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0041",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0041_fa_0017r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1745,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0041"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0041_fa_0017r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0042",
+      "@type" : "sc:Canvas",
+      "label" : "17v",
+      "width" : 1815,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0042",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0042",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0042_fa_0017v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1815,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0042"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0042_fa_0017v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0043",
+      "@type" : "sc:Canvas",
+      "label" : "18r",
+      "width" : 1765,
+      "height" : 2774,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0043",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0043",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0043_fa_0018r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1765,
+          "height" : 2774
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0043"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0043_fa_0018r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 95,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0044",
+      "@type" : "sc:Canvas",
+      "label" : "18v",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0044",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0044",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0044_fa_0018v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0044"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0044_fa_0018v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0045",
+      "@type" : "sc:Canvas",
+      "label" : "19r",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0045",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0045",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0045_fa_0019r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0045"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0045_fa_0019r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0046",
+      "@type" : "sc:Canvas",
+      "label" : "19v",
+      "width" : 1845,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0046",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0046",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0046_fa_0019v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1845,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0046"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0046_fa_0019v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0047",
+      "@type" : "sc:Canvas",
+      "label" : "20r",
+      "width" : 1725,
+      "height" : 2771,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0047",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0047",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0047_fa_0020r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1725,
+          "height" : 2771
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0047"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0047_fa_0020r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 93,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0048",
+      "@type" : "sc:Canvas",
+      "label" : "20v",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0048",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0048",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0048_fa_0020v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0048"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0048_fa_0020v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0049",
+      "@type" : "sc:Canvas",
+      "label" : "21r",
+      "width" : 1695,
+      "height" : 2769,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0049",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0049",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0049_fa_0021r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1695,
+          "height" : 2769
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0049"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0049_fa_0021r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 91,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0050",
+      "@type" : "sc:Canvas",
+      "label" : "21v",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0050",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0050",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0050_fa_0021v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0050"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0050_fa_0021v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0051",
+      "@type" : "sc:Canvas",
+      "label" : "22r",
+      "width" : 1700,
+      "height" : 2769,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0051",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0051",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0051_fa_0022r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1700,
+          "height" : 2769
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0051"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0051_fa_0022r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 92,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0052",
+      "@type" : "sc:Canvas",
+      "label" : "22v",
+      "width" : 1750,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0052",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0052",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0052_fa_0022v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1750,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0052"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0052_fa_0022v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0053",
+      "@type" : "sc:Canvas",
+      "label" : "23r",
+      "width" : 1730,
+      "height" : 2771,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0053",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0053",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0053_fa_0023r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1730,
+          "height" : 2771
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0053"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0053_fa_0023r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 93,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0054",
+      "@type" : "sc:Canvas",
+      "label" : "23v",
+      "width" : 1775,
+      "height" : 2774,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0054",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0054",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0054_fa_0023v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1775,
+          "height" : 2774
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0054"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0054_fa_0023v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 95,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0055",
+      "@type" : "sc:Canvas",
+      "label" : "24r",
+      "width" : 1730,
+      "height" : 2771,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0055",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0055",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0055_fa_0024r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1730,
+          "height" : 2771
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0055"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0055_fa_0024r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 93,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0056",
+      "@type" : "sc:Canvas",
+      "label" : "24v",
+      "width" : 1815,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0056",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0056",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0056_fa_0024v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1815,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0056"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0056_fa_0024v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0057",
+      "@type" : "sc:Canvas",
+      "label" : "25r",
+      "width" : 1755,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0057",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0057",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0057_fa_0025r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1755,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0057"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0057_fa_0025r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0058",
+      "@type" : "sc:Canvas",
+      "label" : "25v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0058",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0058",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0058_fa_0025v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0058"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0058_fa_0025v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0059",
+      "@type" : "sc:Canvas",
+      "label" : "26r",
+      "width" : 1755,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0059",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0059",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0059_fa_0026r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1755,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0059"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0059_fa_0026r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0060",
+      "@type" : "sc:Canvas",
+      "label" : "26v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0060",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0060",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0060_fa_0026v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0060"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0060_fa_0026v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0061",
+      "@type" : "sc:Canvas",
+      "label" : "27r",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0061",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0061",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0061_fa_0027r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0061"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0061_fa_0027r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0062",
+      "@type" : "sc:Canvas",
+      "label" : "27v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0062",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0062",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0062_fa_0027v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0062"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0062_fa_0027v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0063",
+      "@type" : "sc:Canvas",
+      "label" : "28r",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0063",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0063",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0063_fa_0028r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0063"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0063_fa_0028r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0064",
+      "@type" : "sc:Canvas",
+      "label" : "28v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0064",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0064",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0064_fa_0028v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0064"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0064_fa_0028v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0065",
+      "@type" : "sc:Canvas",
+      "label" : "29r",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0065",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0065",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0065_fa_0029r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0065"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0065_fa_0029r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0066",
+      "@type" : "sc:Canvas",
+      "label" : "29v",
+      "width" : 1810,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0066",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0066",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0066_fa_0029v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1810,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0066"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0066_fa_0029v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0067",
+      "@type" : "sc:Canvas",
+      "label" : "30r",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0067",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0067",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0067_fa_0030r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0067"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0067_fa_0030r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0068",
+      "@type" : "sc:Canvas",
+      "label" : "30v",
+      "width" : 1795,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0068",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0068",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0068_fa_0030v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1795,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0068"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0068_fa_0030v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0069",
+      "@type" : "sc:Canvas",
+      "label" : "31r",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0069",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0069",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0069_fa_0031r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0069"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0069_fa_0031r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0070",
+      "@type" : "sc:Canvas",
+      "label" : "31v",
+      "width" : 1795,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0070",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0070",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0070_fa_0031v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1795,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0070"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0070_fa_0031v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0071",
+      "@type" : "sc:Canvas",
+      "label" : "32r",
+      "width" : 1710,
+      "height" : 2770,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0071",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0071",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0071_fa_0032r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1710,
+          "height" : 2770
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0071"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0071_fa_0032r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 92,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0072",
+      "@type" : "sc:Canvas",
+      "label" : "32v",
+      "width" : 1795,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0072",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0072",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0072_fa_0032v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1795,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0072"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0072_fa_0032v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0073",
+      "@type" : "sc:Canvas",
+      "label" : "33r",
+      "width" : 1710,
+      "height" : 2770,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0073",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0073",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0073_fa_0033r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1710,
+          "height" : 2770
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0073"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0073_fa_0033r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 92,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0074",
+      "@type" : "sc:Canvas",
+      "label" : "33v",
+      "width" : 1765,
+      "height" : 2774,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0074",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0074",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0074_fa_0033v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1765,
+          "height" : 2774
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0074"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0074_fa_0033v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 95,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0075",
+      "@type" : "sc:Canvas",
+      "label" : "34r",
+      "width" : 1710,
+      "height" : 2770,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0075",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0075",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0075_fa_0034r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1710,
+          "height" : 2770
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0075"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0075_fa_0034r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 92,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0076",
+      "@type" : "sc:Canvas",
+      "label" : "34v",
+      "width" : 1765,
+      "height" : 2774,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0076",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0076",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0076_fa_0034v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1765,
+          "height" : 2774
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0076"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0076_fa_0034v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 95,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0077",
+      "@type" : "sc:Canvas",
+      "label" : "35r",
+      "width" : 1710,
+      "height" : 2770,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0077",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0077",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0077_fa_0035r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1710,
+          "height" : 2770
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0077"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0077_fa_0035r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 92,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0078",
+      "@type" : "sc:Canvas",
+      "label" : "35v",
+      "width" : 1775,
+      "height" : 2774,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0078",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0078",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0078_fa_0035v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1775,
+          "height" : 2774
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0078"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0078_fa_0035v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 95,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0079",
+      "@type" : "sc:Canvas",
+      "label" : "36r",
+      "width" : 1710,
+      "height" : 2770,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0079",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0079",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0079_fa_0036r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1710,
+          "height" : 2770
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0079"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0079_fa_0036r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 92,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0080",
+      "@type" : "sc:Canvas",
+      "label" : "36v",
+      "width" : 1775,
+      "height" : 2774,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0080",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0080",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0080_fa_0036v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1775,
+          "height" : 2774
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0080"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0080_fa_0036v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 95,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0081",
+      "@type" : "sc:Canvas",
+      "label" : "37r",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0081",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0081",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0081_fa_0037r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0081"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0081_fa_0037r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0082",
+      "@type" : "sc:Canvas",
+      "label" : "37v",
+      "width" : 1755,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0082",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0082",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0082_fa_0037v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1755,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0082"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0082_fa_0037v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0083",
+      "@type" : "sc:Canvas",
+      "label" : "38r",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0083",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0083",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0083_fa_0038r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0083"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0083_fa_0038r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0084",
+      "@type" : "sc:Canvas",
+      "label" : "38v",
+      "width" : 1755,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0084",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0084",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0084_fa_0038v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1755,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0084"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0084_fa_0038v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0085",
+      "@type" : "sc:Canvas",
+      "label" : "39r",
+      "width" : 1750,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0085",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0085",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0085_fa_0039r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1750,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0085"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0085_fa_0039r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0086",
+      "@type" : "sc:Canvas",
+      "label" : "39v",
+      "width" : 1755,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0086",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0086",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0086_fa_0039v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1755,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0086"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0086_fa_0039v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0087",
+      "@type" : "sc:Canvas",
+      "label" : "40r",
+      "width" : 1775,
+      "height" : 2774,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0087",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0087",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0087_fa_0040r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1775,
+          "height" : 2774
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0087"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0087_fa_0040r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 95,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0088",
+      "@type" : "sc:Canvas",
+      "label" : "40v",
+      "width" : 1765,
+      "height" : 2774,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0088",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0088",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0088_fa_0040v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1765,
+          "height" : 2774
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0088"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0088_fa_0040v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 95,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0089",
+      "@type" : "sc:Canvas",
+      "label" : "41r",
+      "width" : 1785,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0089",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0089",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0089_fa_0041r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1785,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0089"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0089_fa_0041r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0090",
+      "@type" : "sc:Canvas",
+      "label" : "41v",
+      "width" : 1750,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0090",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0090",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0090_fa_0041v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1750,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0090"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0090_fa_0041v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0091",
+      "@type" : "sc:Canvas",
+      "label" : "42r",
+      "width" : 1785,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0091",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0091",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0091_fa_0042r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1785,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0091"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0091_fa_0042r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0092",
+      "@type" : "sc:Canvas",
+      "label" : "42v",
+      "width" : 1795,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0092",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0092",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0092_fa_0042v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1795,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0092"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0092_fa_0042v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0093",
+      "@type" : "sc:Canvas",
+      "label" : "43r",
+      "width" : 1760,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0093",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0093",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0093_fa_0043r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1760,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0093"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0093_fa_0043r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 95,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0094",
+      "@type" : "sc:Canvas",
+      "label" : "43v",
+      "width" : 1795,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0094",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0094",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0094_fa_0043v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1795,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0094"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0094_fa_0043v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0095",
+      "@type" : "sc:Canvas",
+      "label" : "44r",
+      "width" : 1760,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0095",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0095",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0095_fa_0044r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1760,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0095"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0095_fa_0044r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 95,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0096",
+      "@type" : "sc:Canvas",
+      "label" : "44v",
+      "width" : 1795,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0096",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0096",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0096_fa_0044v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1795,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0096"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0096_fa_0044v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0097",
+      "@type" : "sc:Canvas",
+      "label" : "45r",
+      "width" : 1760,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0097",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0097",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0097_fa_0045r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1760,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0097"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0097_fa_0045r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 95,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0098",
+      "@type" : "sc:Canvas",
+      "label" : "45v",
+      "width" : 1795,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0098",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0098",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0098_fa_0045v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1795,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0098"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0098_fa_0045v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0099",
+      "@type" : "sc:Canvas",
+      "label" : "46r",
+      "width" : 1815,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0099",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0099",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0099_fa_0046r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1815,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0099"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0099_fa_0046r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0100",
+      "@type" : "sc:Canvas",
+      "label" : "46v",
+      "width" : 1800,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0100",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0100",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0100_fa_0046v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1800,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0100"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0100_fa_0046v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0101",
+      "@type" : "sc:Canvas",
+      "label" : "47r",
+      "width" : 1815,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0101",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0101",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0101_fa_0047r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1815,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0101"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0101_fa_0047r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0102",
+      "@type" : "sc:Canvas",
+      "label" : "47v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0102",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0102",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0102_fa_0047v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0102"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0102_fa_0047v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0103",
+      "@type" : "sc:Canvas",
+      "label" : "48r",
+      "width" : 1815,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0103",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0103",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0103_fa_0048r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1815,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0103"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0103_fa_0048r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0104",
+      "@type" : "sc:Canvas",
+      "label" : "48v",
+      "width" : 1800,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0104",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0104",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0104_fa_0048v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1800,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0104"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0104_fa_0048v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0105",
+      "@type" : "sc:Canvas",
+      "label" : "49r",
+      "width" : 1815,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0105",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0105",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0105_fa_0049r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1815,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0105"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0105_fa_0049r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0106",
+      "@type" : "sc:Canvas",
+      "label" : "49v",
+      "width" : 1840,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0106",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0106",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0106_fa_0049v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1840,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0106"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0106_fa_0049v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0107",
+      "@type" : "sc:Canvas",
+      "label" : "50r",
+      "width" : 1815,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0107",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0107",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0107_fa_0050r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1815,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0107"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0107_fa_0050r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0108",
+      "@type" : "sc:Canvas",
+      "label" : "50v",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0108",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0108",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0108_fa_0050v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0108"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0108_fa_0050v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0109",
+      "@type" : "sc:Canvas",
+      "label" : "51r",
+      "width" : 1815,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0109",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0109",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0109_fa_0051r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1815,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0109"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0109_fa_0051r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0110",
+      "@type" : "sc:Canvas",
+      "label" : "51v",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0110",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0110",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0110_fa_0051v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0110"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0110_fa_0051v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0111",
+      "@type" : "sc:Canvas",
+      "label" : "52r",
+      "width" : 1800,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0111",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0111",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0111_fa_0052r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1800,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0111"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0111_fa_0052r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0112",
+      "@type" : "sc:Canvas",
+      "label" : "52v",
+      "width" : 1840,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0112",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0112",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0112_fa_0052v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1840,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0112"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0112_fa_0052v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0113",
+      "@type" : "sc:Canvas",
+      "label" : "53r",
+      "width" : 1800,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0113",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0113",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0113_fa_0053r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1800,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0113"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0113_fa_0053r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0114",
+      "@type" : "sc:Canvas",
+      "label" : "53v",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0114",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0114",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0114_fa_0053v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0114"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0114_fa_0053v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0115",
+      "@type" : "sc:Canvas",
+      "label" : "54r",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0115",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0115",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0115_fa_0054r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0115"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0115_fa_0054r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0116",
+      "@type" : "sc:Canvas",
+      "label" : "54v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0116",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0116",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0116_fa_0054v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0116"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0116_fa_0054v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0117",
+      "@type" : "sc:Canvas",
+      "label" : "55r",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0117",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0117",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0117_fa_0055r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0117"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0117_fa_0055r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0118",
+      "@type" : "sc:Canvas",
+      "label" : "55v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0118",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0118",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0118_fa_0055v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0118"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0118_fa_0055v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0119",
+      "@type" : "sc:Canvas",
+      "label" : "56r",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0119",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0119",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0119_fa_0056r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0119"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0119_fa_0056r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0120",
+      "@type" : "sc:Canvas",
+      "label" : "56v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0120",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0120",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0120_fa_0056v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0120"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0120_fa_0056v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0121",
+      "@type" : "sc:Canvas",
+      "label" : "57r",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0121",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0121",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0121_fa_0057r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0121"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0121_fa_0057r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0122",
+      "@type" : "sc:Canvas",
+      "label" : "57v",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0122",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0122",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0122_fa_0057v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0122"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0122_fa_0057v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0123",
+      "@type" : "sc:Canvas",
+      "label" : "58r",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0123",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0123",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0123_fa_0058r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0123"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0123_fa_0058r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0124",
+      "@type" : "sc:Canvas",
+      "label" : "58v",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0124",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0124",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0124_fa_0058v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0124"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0124_fa_0058v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0125",
+      "@type" : "sc:Canvas",
+      "label" : "59r",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0125",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0125",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0125_fa_0059r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0125"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0125_fa_0059r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0126",
+      "@type" : "sc:Canvas",
+      "label" : "59v",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0126",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0126",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0126_fa_0059v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0126"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0126_fa_0059v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0127",
+      "@type" : "sc:Canvas",
+      "label" : "60r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0127",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0127",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0127_fa_0060r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0127"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0127_fa_0060r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0128",
+      "@type" : "sc:Canvas",
+      "label" : "60v",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0128",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0128",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0128_fa_0060v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0128"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0128_fa_0060v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0129",
+      "@type" : "sc:Canvas",
+      "label" : "61r",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0129",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0129",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0129_fa_0061r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0129"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0129_fa_0061r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0130",
+      "@type" : "sc:Canvas",
+      "label" : "61v",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0130",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0130",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0130_fa_0061v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0130"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0130_fa_0061v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0131",
+      "@type" : "sc:Canvas",
+      "label" : "62r",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0131",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0131",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0131_fa_0062r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0131"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0131_fa_0062r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0132",
+      "@type" : "sc:Canvas",
+      "label" : "62v",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0132",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0132",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0132_fa_0062v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0132"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0132_fa_0062v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0133",
+      "@type" : "sc:Canvas",
+      "label" : "63r",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0133",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0133",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0133_fa_0063r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0133"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0133_fa_0063r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0134",
+      "@type" : "sc:Canvas",
+      "label" : "63v",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0134",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0134",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0134_fa_0063v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0134"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0134_fa_0063v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0135",
+      "@type" : "sc:Canvas",
+      "label" : "64r",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0135",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0135",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0135_fa_0064r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0135"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0135_fa_0064r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0136",
+      "@type" : "sc:Canvas",
+      "label" : "64v",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0136",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0136",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0136_fa_0064v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0136"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0136_fa_0064v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0137",
+      "@type" : "sc:Canvas",
+      "label" : "65r",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0137",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0137",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0137_fa_0065r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0137"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0137_fa_0065r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0138",
+      "@type" : "sc:Canvas",
+      "label" : "65v",
+      "width" : 1840,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0138",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0138",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0138_fa_0065v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1840,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0138"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0138_fa_0065v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0139",
+      "@type" : "sc:Canvas",
+      "label" : "66r",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0139",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0139",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0139_fa_0066r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0139"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0139_fa_0066r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0140",
+      "@type" : "sc:Canvas",
+      "label" : "66v",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0140",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0140",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0140_fa_0066v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0140"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0140_fa_0066v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0141",
+      "@type" : "sc:Canvas",
+      "label" : "67r",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0141",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0141",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0141_fa_0067r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0141"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0141_fa_0067r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0142",
+      "@type" : "sc:Canvas",
+      "label" : "67v",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0142",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0142",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0142_fa_0067v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0142"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0142_fa_0067v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0143",
+      "@type" : "sc:Canvas",
+      "label" : "68r",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0143",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0143",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0143_fa_0068r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0143"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0143_fa_0068r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0144",
+      "@type" : "sc:Canvas",
+      "label" : "68v",
+      "width" : 1855,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0144",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0144",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0144_fa_0068v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1855,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0144"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0144_fa_0068v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0145",
+      "@type" : "sc:Canvas",
+      "label" : "69r",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0145",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0145",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0145_fa_0069r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0145"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0145_fa_0069r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0146",
+      "@type" : "sc:Canvas",
+      "label" : "69v",
+      "width" : 1855,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0146",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0146",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0146_fa_0069v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1855,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0146"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0146_fa_0069v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0147",
+      "@type" : "sc:Canvas",
+      "label" : "70r",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0147",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0147",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0147_fa_0070r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0147"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0147_fa_0070r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0148",
+      "@type" : "sc:Canvas",
+      "label" : "70v",
+      "width" : 1840,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0148",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0148",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0148_fa_0070v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1840,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0148"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0148_fa_0070v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0149",
+      "@type" : "sc:Canvas",
+      "label" : "71r",
+      "width" : 1815,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0149",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0149",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0149_fa_0071r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1815,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0149"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0149_fa_0071r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0150",
+      "@type" : "sc:Canvas",
+      "label" : "71v",
+      "width" : 1840,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0150",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0150",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0150_fa_0071v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1840,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0150"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0150_fa_0071v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0151",
+      "@type" : "sc:Canvas",
+      "label" : "72r",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0151",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0151",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0151_fa_0072r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0151"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0151_fa_0072r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0152",
+      "@type" : "sc:Canvas",
+      "label" : "72v",
+      "width" : 1845,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0152",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0152",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0152_fa_0072v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1845,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0152"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0152_fa_0072v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0153",
+      "@type" : "sc:Canvas",
+      "label" : "73r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0153",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0153",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0153_fa_0073r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0153"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0153_fa_0073r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0154",
+      "@type" : "sc:Canvas",
+      "label" : "73v",
+      "width" : 1840,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0154",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0154",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0154_fa_0073v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1840,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0154"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0154_fa_0073v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0155",
+      "@type" : "sc:Canvas",
+      "label" : "74r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0155",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0155",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0155_fa_0074r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0155"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0155_fa_0074r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0156",
+      "@type" : "sc:Canvas",
+      "label" : "74v",
+      "width" : 1855,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0156",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0156",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0156_fa_0074v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1855,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0156"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0156_fa_0074v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0157",
+      "@type" : "sc:Canvas",
+      "label" : "75r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0157",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0157",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0157_fa_0075r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0157"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0157_fa_0075r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0158",
+      "@type" : "sc:Canvas",
+      "label" : "75v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0158",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0158",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0158_fa_0075v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0158"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0158_fa_0075v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0159",
+      "@type" : "sc:Canvas",
+      "label" : "76r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0159",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0159",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0159_fa_0076r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0159"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0159_fa_0076r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0160",
+      "@type" : "sc:Canvas",
+      "label" : "76v",
+      "width" : 1845,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0160",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0160",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0160_fa_0076v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1845,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0160"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0160_fa_0076v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0161",
+      "@type" : "sc:Canvas",
+      "label" : "77r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0161",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0161",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0161_fa_0077r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0161"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0161_fa_0077r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0162",
+      "@type" : "sc:Canvas",
+      "label" : "77v",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0162",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0162",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0162_fa_0077v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0162"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0162_fa_0077v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0163",
+      "@type" : "sc:Canvas",
+      "label" : "78r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0163",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0163",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0163_fa_0078r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0163"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0163_fa_0078r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0164",
+      "@type" : "sc:Canvas",
+      "label" : "78v",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0164",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0164",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0164_fa_0078v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0164"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0164_fa_0078v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0165",
+      "@type" : "sc:Canvas",
+      "label" : "79r",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0165",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0165",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0165_fa_0079r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0165"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0165_fa_0079r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0166",
+      "@type" : "sc:Canvas",
+      "label" : "79v",
+      "width" : 1845,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0166",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0166",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0166_fa_0079v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1845,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0166"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0166_fa_0079v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0167",
+      "@type" : "sc:Canvas",
+      "label" : "80r",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0167",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0167",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0167_fa_0080r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0167"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0167_fa_0080r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0168",
+      "@type" : "sc:Canvas",
+      "label" : "80v",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0168",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0168",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0168_fa_0080v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0168"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0168_fa_0080v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0169",
+      "@type" : "sc:Canvas",
+      "label" : "81r",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0169",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0169",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0169_fa_0081r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0169"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0169_fa_0081r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0170",
+      "@type" : "sc:Canvas",
+      "label" : "81v",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0170",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0170",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0170_fa_0081v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0170"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0170_fa_0081v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0171",
+      "@type" : "sc:Canvas",
+      "label" : "82r",
+      "width" : 1820,
+      "height" : 2777,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0171",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0171",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0171_fa_0082r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1820,
+          "height" : 2777
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0171"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0171_fa_0082r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0172",
+      "@type" : "sc:Canvas",
+      "label" : "82v",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0172",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0172",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0172_fa_0082v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0172"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0172_fa_0082v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0173",
+      "@type" : "sc:Canvas",
+      "label" : "83r",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0173",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0173",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0173_fa_0083r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0173"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0173_fa_0083r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0174",
+      "@type" : "sc:Canvas",
+      "label" : "83v",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0174",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0174",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0174_fa_0083v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0174"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0174_fa_0083v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0175",
+      "@type" : "sc:Canvas",
+      "label" : "84r",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0175",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0175",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0175_fa_0084r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0175"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0175_fa_0084r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0176",
+      "@type" : "sc:Canvas",
+      "label" : "84v",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0176",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0176",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0176_fa_0084v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0176"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0176_fa_0084v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0177",
+      "@type" : "sc:Canvas",
+      "label" : "85r",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0177",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0177",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0177_fa_0085r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0177"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0177_fa_0085r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0178",
+      "@type" : "sc:Canvas",
+      "label" : "85v",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0178",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0178",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0178_fa_0085v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0178"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0178_fa_0085v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0179",
+      "@type" : "sc:Canvas",
+      "label" : "86r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0179",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0179",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0179_fa_0086r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0179"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0179_fa_0086r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0180",
+      "@type" : "sc:Canvas",
+      "label" : "86v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0180",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0180",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0180_fa_0086v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0180"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0180_fa_0086v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0181",
+      "@type" : "sc:Canvas",
+      "label" : "87r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0181",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0181",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0181_fa_0087r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0181"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0181_fa_0087r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0182",
+      "@type" : "sc:Canvas",
+      "label" : "87v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0182",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0182",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0182_fa_0087v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0182"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0182_fa_0087v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0183",
+      "@type" : "sc:Canvas",
+      "label" : "88r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0183",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0183",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0183_fa_0088r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0183"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0183_fa_0088r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0184",
+      "@type" : "sc:Canvas",
+      "label" : "88v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0184",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0184",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0184_fa_0088v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0184"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0184_fa_0088v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0185",
+      "@type" : "sc:Canvas",
+      "label" : "89r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0185",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0185",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0185_fa_0089r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0185"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0185_fa_0089r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0186",
+      "@type" : "sc:Canvas",
+      "label" : "89v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0186",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0186",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0186_fa_0089v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0186"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0186_fa_0089v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0187",
+      "@type" : "sc:Canvas",
+      "label" : "90r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0187",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0187",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0187_fa_0090r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0187"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0187_fa_0090r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0188",
+      "@type" : "sc:Canvas",
+      "label" : "90v",
+      "width" : 1890,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0188",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0188",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0188_fa_0090v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1890,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0188"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0188_fa_0090v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0189",
+      "@type" : "sc:Canvas",
+      "label" : "91r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0189",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0189",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0189_fa_0091r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0189"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0189_fa_0091r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0190",
+      "@type" : "sc:Canvas",
+      "label" : "91v",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0190",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0190",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0190_fa_0091v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0190"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0190_fa_0091v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0191",
+      "@type" : "sc:Canvas",
+      "label" : "92r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0191",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0191",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0191_fa_0092r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0191"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0191_fa_0092r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0192",
+      "@type" : "sc:Canvas",
+      "label" : "92v",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0192",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0192",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0192_fa_0092v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0192"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0192_fa_0092v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0193",
+      "@type" : "sc:Canvas",
+      "label" : "93r",
+      "width" : 1845,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0193",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0193",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0193_fa_0093r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1845,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0193"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0193_fa_0093r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0194",
+      "@type" : "sc:Canvas",
+      "label" : "93v",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0194",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0194",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0194_fa_0093v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0194"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0194_fa_0093v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0195",
+      "@type" : "sc:Canvas",
+      "label" : "94r",
+      "width" : 1855,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0195",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0195",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0195_fa_0094r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1855,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0195"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0195_fa_0094r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0196",
+      "@type" : "sc:Canvas",
+      "label" : "94v",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0196",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0196",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0196_fa_0094v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0196"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0196_fa_0094v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0197",
+      "@type" : "sc:Canvas",
+      "label" : "95r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0197",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0197",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0197_fa_0095r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0197"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0197_fa_0095r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0198",
+      "@type" : "sc:Canvas",
+      "label" : "95v",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0198",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0198",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0198_fa_0095v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0198"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0198_fa_0095v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0199",
+      "@type" : "sc:Canvas",
+      "label" : "96r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0199",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0199",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0199_fa_0096r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0199"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0199_fa_0096r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0200",
+      "@type" : "sc:Canvas",
+      "label" : "96v",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0200",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0200",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0200_fa_0096v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0200"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0200_fa_0096v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0201",
+      "@type" : "sc:Canvas",
+      "label" : "97r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0201",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0201",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0201_fa_0097r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0201"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0201_fa_0097r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0202",
+      "@type" : "sc:Canvas",
+      "label" : "97v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0202",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0202",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0202_fa_0097v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0202"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0202_fa_0097v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0203",
+      "@type" : "sc:Canvas",
+      "label" : "98r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0203",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0203",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0203_fa_0098r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0203"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0203_fa_0098r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0204",
+      "@type" : "sc:Canvas",
+      "label" : "98v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0204",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0204",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0204_fa_0098v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0204"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0204_fa_0098v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0205",
+      "@type" : "sc:Canvas",
+      "label" : "99r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0205",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0205",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0205_fa_0099r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0205"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0205_fa_0099r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0206",
+      "@type" : "sc:Canvas",
+      "label" : "99v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0206",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0206",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0206_fa_0099v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0206"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0206_fa_0099v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0207",
+      "@type" : "sc:Canvas",
+      "label" : "100r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0207",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0207",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0207_fa_0100r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0207"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0207_fa_0100r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0208",
+      "@type" : "sc:Canvas",
+      "label" : "100v",
+      "width" : 1840,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0208",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0208",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0208_fa_0100v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1840,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0208"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0208_fa_0100v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0209",
+      "@type" : "sc:Canvas",
+      "label" : "101r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0209",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0209",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0209_fa_0101r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0209"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0209_fa_0101r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0210",
+      "@type" : "sc:Canvas",
+      "label" : "101v",
+      "width" : 1840,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0210",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0210",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0210_fa_0101v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1840,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0210"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0210_fa_0101v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0211",
+      "@type" : "sc:Canvas",
+      "label" : "102r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0211",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0211",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0211_fa_0102r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0211"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0211_fa_0102r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0212",
+      "@type" : "sc:Canvas",
+      "label" : "102v",
+      "width" : 1845,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0212",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0212",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0212_fa_0102v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1845,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0212"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0212_fa_0102v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0213",
+      "@type" : "sc:Canvas",
+      "label" : "103r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0213",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0213",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0213_fa_0103r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0213"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0213_fa_0103r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0214",
+      "@type" : "sc:Canvas",
+      "label" : "103v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0214",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0214",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0214_fa_0103v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0214"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0214_fa_0103v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0215",
+      "@type" : "sc:Canvas",
+      "label" : "104r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0215",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0215",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0215_fa_0104r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0215"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0215_fa_0104r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0216",
+      "@type" : "sc:Canvas",
+      "label" : "104v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0216",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0216",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0216_fa_0104v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0216"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0216_fa_0104v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0217",
+      "@type" : "sc:Canvas",
+      "label" : "105r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0217",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0217",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0217_fa_0105r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0217"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0217_fa_0105r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0218",
+      "@type" : "sc:Canvas",
+      "label" : "105v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0218",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0218",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0218_fa_0105v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0218"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0218_fa_0105v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0219",
+      "@type" : "sc:Canvas",
+      "label" : "106r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0219",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0219",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0219_fa_0106r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0219"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0219_fa_0106r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0220",
+      "@type" : "sc:Canvas",
+      "label" : "106v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0220",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0220",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0220_fa_0106v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0220"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0220_fa_0106v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0221",
+      "@type" : "sc:Canvas",
+      "label" : "107r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0221",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0221",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0221_fa_0107r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0221"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0221_fa_0107r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0222",
+      "@type" : "sc:Canvas",
+      "label" : "107v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0222",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0222",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0222_fa_0107v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0222"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0222_fa_0107v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0223",
+      "@type" : "sc:Canvas",
+      "label" : "108r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0223",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0223",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0223_fa_0108r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0223"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0223_fa_0108r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0224",
+      "@type" : "sc:Canvas",
+      "label" : "108v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0224",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0224",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0224_fa_0108v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0224"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0224_fa_0108v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0225",
+      "@type" : "sc:Canvas",
+      "label" : "109r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0225",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0225",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0225_fa_0109r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0225"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0225_fa_0109r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0226",
+      "@type" : "sc:Canvas",
+      "label" : "109v",
+      "width" : 1840,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0226",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0226",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0226_fa_0109v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1840,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0226"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0226_fa_0109v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0227",
+      "@type" : "sc:Canvas",
+      "label" : "110r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0227",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0227",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0227_fa_0110r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0227"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0227_fa_0110r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0228",
+      "@type" : "sc:Canvas",
+      "label" : "110v",
+      "width" : 1840,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0228",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0228",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0228_fa_0110v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1840,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0228"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0228_fa_0110v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0229",
+      "@type" : "sc:Canvas",
+      "label" : "111r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0229",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0229",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0229_fa_0111r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0229"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0229_fa_0111r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0230",
+      "@type" : "sc:Canvas",
+      "label" : "111v",
+      "width" : 1840,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0230",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0230",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0230_fa_0111v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1840,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0230"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0230_fa_0111v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0231",
+      "@type" : "sc:Canvas",
+      "label" : "112r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0231",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0231",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0231_fa_0112r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0231"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0231_fa_0112r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0232",
+      "@type" : "sc:Canvas",
+      "label" : "112v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0232",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0232",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0232_fa_0112v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0232"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0232_fa_0112v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0233",
+      "@type" : "sc:Canvas",
+      "label" : "113r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0233",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0233",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0233_fa_0113r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0233"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0233_fa_0113r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0234",
+      "@type" : "sc:Canvas",
+      "label" : "113v",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0234",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0234",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0234_fa_0113v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0234"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0234_fa_0113v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0235",
+      "@type" : "sc:Canvas",
+      "label" : "114r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0235",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0235",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0235_fa_0114r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0235"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0235_fa_0114r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0236",
+      "@type" : "sc:Canvas",
+      "label" : "114v",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0236",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0236",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0236_fa_0114v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0236"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0236_fa_0114v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0237",
+      "@type" : "sc:Canvas",
+      "label" : "115r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0237",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0237",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0237_fa_0115r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0237"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0237_fa_0115r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0238",
+      "@type" : "sc:Canvas",
+      "label" : "115v",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0238",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0238",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0238_fa_0115v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0238"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0238_fa_0115v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0239",
+      "@type" : "sc:Canvas",
+      "label" : "116r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0239",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0239",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0239_fa_0116r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0239"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0239_fa_0116r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0240",
+      "@type" : "sc:Canvas",
+      "label" : "116v",
+      "width" : 1850,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0240",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0240",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0240_fa_0116v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1850,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0240"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0240_fa_0116v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0241",
+      "@type" : "sc:Canvas",
+      "label" : "117r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0241",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0241",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0241_fa_0117r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0241"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0241_fa_0117r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0242",
+      "@type" : "sc:Canvas",
+      "label" : "117v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0242",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0242",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0242_fa_0117v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0242"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0242_fa_0117v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0243",
+      "@type" : "sc:Canvas",
+      "label" : "118r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0243",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0243",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0243_fa_0118r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0243"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0243_fa_0118r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0244",
+      "@type" : "sc:Canvas",
+      "label" : "118v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0244",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0244",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0244_fa_0118v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0244"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0244_fa_0118v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0245",
+      "@type" : "sc:Canvas",
+      "label" : "119r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0245",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0245",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0245_fa_0119r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0245"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0245_fa_0119r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0246",
+      "@type" : "sc:Canvas",
+      "label" : "119v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0246",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0246",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0246_fa_0119v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0246"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0246_fa_0119v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0247",
+      "@type" : "sc:Canvas",
+      "label" : "120r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0247",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0247",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0247_fa_0120r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0247"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0247_fa_0120r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0248",
+      "@type" : "sc:Canvas",
+      "label" : "120v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0248",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0248",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0248_fa_0120v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0248"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0248_fa_0120v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0249",
+      "@type" : "sc:Canvas",
+      "label" : "121r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0249",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0249",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0249_fa_0121r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0249"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0249_fa_0121r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0250",
+      "@type" : "sc:Canvas",
+      "label" : "121v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0250",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0250",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0250_fa_0121v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0250"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0250_fa_0121v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0251",
+      "@type" : "sc:Canvas",
+      "label" : "122r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0251",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0251",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0251_fa_0122r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0251"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0251_fa_0122r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0252",
+      "@type" : "sc:Canvas",
+      "label" : "122v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0252",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0252",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0252_fa_0122v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0252"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0252_fa_0122v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0253",
+      "@type" : "sc:Canvas",
+      "label" : "123r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0253",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0253",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0253_fa_0123r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0253"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0253_fa_0123r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0254",
+      "@type" : "sc:Canvas",
+      "label" : "123v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0254",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0254",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0254_fa_0123v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0254"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0254_fa_0123v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0255",
+      "@type" : "sc:Canvas",
+      "label" : "124r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0255",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0255",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0255_fa_0124r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0255"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0255_fa_0124r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0256",
+      "@type" : "sc:Canvas",
+      "label" : "124v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0256",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0256",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0256_fa_0124v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0256"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0256_fa_0124v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0257",
+      "@type" : "sc:Canvas",
+      "label" : "125r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0257",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0257",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0257_fa_0125r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0257"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0257_fa_0125r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0258",
+      "@type" : "sc:Canvas",
+      "label" : "125v",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0258",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0258",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0258_fa_0125v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0258"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0258_fa_0125v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0259",
+      "@type" : "sc:Canvas",
+      "label" : "126r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0259",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0259",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0259_fa_0126r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0259"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0259_fa_0126r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0260",
+      "@type" : "sc:Canvas",
+      "label" : "126v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0260",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0260",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0260_fa_0126v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0260"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0260_fa_0126v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0261",
+      "@type" : "sc:Canvas",
+      "label" : "127r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0261",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0261",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0261_fa_0127r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0261"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0261_fa_0127r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0262",
+      "@type" : "sc:Canvas",
+      "label" : "127v",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0262",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0262",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0262_fa_0127v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0262"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0262_fa_0127v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0263",
+      "@type" : "sc:Canvas",
+      "label" : "128r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0263",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0263",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0263_fa_0128r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0263"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0263_fa_0128r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0264",
+      "@type" : "sc:Canvas",
+      "label" : "128v",
+      "width" : 1875,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0264",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0264",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0264_fa_0128v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1875,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0264"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0264_fa_0128v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0265",
+      "@type" : "sc:Canvas",
+      "label" : "129r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0265",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0265",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0265_fa_0129r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0265"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0265_fa_0129r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0266",
+      "@type" : "sc:Canvas",
+      "label" : "129v",
+      "width" : 1860,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0266",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0266",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0266_fa_0129v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1860,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0266"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0266_fa_0129v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0267",
+      "@type" : "sc:Canvas",
+      "label" : "130r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0267",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0267",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0267_fa_0130r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0267"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0267_fa_0130r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0268",
+      "@type" : "sc:Canvas",
+      "label" : "130v",
+      "width" : 1875,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0268",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0268",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0268_fa_0130v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1875,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0268"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0268_fa_0130v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0269",
+      "@type" : "sc:Canvas",
+      "label" : "131r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0269",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0269",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0269_fa_0131r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0269"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0269_fa_0131r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0270",
+      "@type" : "sc:Canvas",
+      "label" : "131v",
+      "width" : 1845,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0270",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0270",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0270_fa_0131v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1845,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0270"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0270_fa_0131v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0271",
+      "@type" : "sc:Canvas",
+      "label" : "132r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0271",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0271",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0271_fa_0132r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0271"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0271_fa_0132r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0272",
+      "@type" : "sc:Canvas",
+      "label" : "132v",
+      "width" : 1845,
+      "height" : 2779,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0272",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0272",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0272_fa_0132v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1845,
+          "height" : 2779
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0272"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0272_fa_0132v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0273",
+      "@type" : "sc:Canvas",
+      "label" : "133r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0273",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0273",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0273_fa_0133r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0273"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0273_fa_0133r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0274",
+      "@type" : "sc:Canvas",
+      "label" : "133v",
+      "width" : 1855,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0274",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0274",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0274_fa_0133v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1855,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0274"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0274_fa_0133v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0275",
+      "@type" : "sc:Canvas",
+      "label" : "134r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0275",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0275",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0275_fa_0134r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0275"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0275_fa_0134r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0276",
+      "@type" : "sc:Canvas",
+      "label" : "134v",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0276",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0276",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0276_fa_0134v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0276"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0276_fa_0134v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0277",
+      "@type" : "sc:Canvas",
+      "label" : "135r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0277",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0277",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0277_fa_0135r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0277"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0277_fa_0135r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0278",
+      "@type" : "sc:Canvas",
+      "label" : "135v",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0278",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0278",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0278_fa_0135v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0278"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0278_fa_0135v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0279",
+      "@type" : "sc:Canvas",
+      "label" : "136r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0279",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0279",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0279_fa_0136r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0279"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0279_fa_0136r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0280",
+      "@type" : "sc:Canvas",
+      "label" : "136v",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0280",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0280",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0280_fa_0136v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0280"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0280_fa_0136v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0281",
+      "@type" : "sc:Canvas",
+      "label" : "137r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0281",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0281",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0281_fa_0137r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0281"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0281_fa_0137r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0282",
+      "@type" : "sc:Canvas",
+      "label" : "137v",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0282",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0282",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0282_fa_0137v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0282"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0282_fa_0137v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0283",
+      "@type" : "sc:Canvas",
+      "label" : "138r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0283",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0283",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0283_fa_0138r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0283"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0283_fa_0138r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0284",
+      "@type" : "sc:Canvas",
+      "label" : "138v",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0284",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0284",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0284_fa_0138v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0284"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0284_fa_0138v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0285",
+      "@type" : "sc:Canvas",
+      "label" : "139r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0285",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0285",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0285_fa_0139r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0285"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0285_fa_0139r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0286",
+      "@type" : "sc:Canvas",
+      "label" : "139v",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0286",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0286",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0286_fa_0139v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0286"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0286_fa_0139v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0287",
+      "@type" : "sc:Canvas",
+      "label" : "140r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0287",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0287",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0287_fa_0140r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0287"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0287_fa_0140r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0288",
+      "@type" : "sc:Canvas",
+      "label" : "140v",
+      "width" : 1855,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0288",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0288",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0288_fa_0140v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1855,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0288"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0288_fa_0140v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0289",
+      "@type" : "sc:Canvas",
+      "label" : "141r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0289",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0289",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0289_fa_0141r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0289"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0289_fa_0141r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0290",
+      "@type" : "sc:Canvas",
+      "label" : "141v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0290",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0290",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0290_fa_0141v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0290"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0290_fa_0141v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0291",
+      "@type" : "sc:Canvas",
+      "label" : "142r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0291",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0291",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0291_fa_0142r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0291"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0291_fa_0142r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0292",
+      "@type" : "sc:Canvas",
+      "label" : "142v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0292",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0292",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0292_fa_0142v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0292"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0292_fa_0142v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0293",
+      "@type" : "sc:Canvas",
+      "label" : "143r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0293",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0293",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0293_fa_0143r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0293"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0293_fa_0143r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0294",
+      "@type" : "sc:Canvas",
+      "label" : "143v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0294",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0294",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0294_fa_0143v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0294"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0294_fa_0143v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0295",
+      "@type" : "sc:Canvas",
+      "label" : "144r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0295",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0295",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0295_fa_0144r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0295"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0295_fa_0144r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0296",
+      "@type" : "sc:Canvas",
+      "label" : "144v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0296",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0296",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0296_fa_0144v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0296"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0296_fa_0144v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0297",
+      "@type" : "sc:Canvas",
+      "label" : "145r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0297",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0297",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0297_fa_0145r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0297"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0297_fa_0145r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0298",
+      "@type" : "sc:Canvas",
+      "label" : "145v",
+      "width" : 1890,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0298",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0298",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0298_fa_0145v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1890,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0298"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0298_fa_0145v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0299",
+      "@type" : "sc:Canvas",
+      "label" : "146r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0299",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0299",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0299_fa_0146r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0299"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0299_fa_0146r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0300",
+      "@type" : "sc:Canvas",
+      "label" : "146v",
+      "width" : 1890,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0300",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0300",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0300_fa_0146v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1890,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0300"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0300_fa_0146v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0301",
+      "@type" : "sc:Canvas",
+      "label" : "147r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0301",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0301",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0301_fa_0147r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0301"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0301_fa_0147r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0302",
+      "@type" : "sc:Canvas",
+      "label" : "147v",
+      "width" : 1890,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0302",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0302",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0302_fa_0147v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1890,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0302"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0302_fa_0147v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0303",
+      "@type" : "sc:Canvas",
+      "label" : "148r",
+      "width" : 1915,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0303",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0303",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0303_fa_0148r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1915,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0303"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0303_fa_0148r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0304",
+      "@type" : "sc:Canvas",
+      "label" : "148v",
+      "width" : 1875,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0304",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0304",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0304_fa_0148v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1875,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0304"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0304_fa_0148v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0305",
+      "@type" : "sc:Canvas",
+      "label" : "149r",
+      "width" : 1915,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0305",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0305",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0305_fa_0149r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1915,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0305"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0305_fa_0149r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0306",
+      "@type" : "sc:Canvas",
+      "label" : "149v",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0306",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0306",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0306_fa_0149v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0306"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0306_fa_0149v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0307",
+      "@type" : "sc:Canvas",
+      "label" : "150r",
+      "width" : 1915,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0307",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0307",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0307_fa_0150r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1915,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0307"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0307_fa_0150r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0308",
+      "@type" : "sc:Canvas",
+      "label" : "150v",
+      "width" : 1890,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0308",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0308",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0308_fa_0150v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1890,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0308"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0308_fa_0150v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0309",
+      "@type" : "sc:Canvas",
+      "label" : "151r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0309",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0309",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0309_fa_0151r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0309"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0309_fa_0151r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0310",
+      "@type" : "sc:Canvas",
+      "label" : "151v",
+      "width" : 1890,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0310",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0310",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0310_fa_0151v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1890,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0310"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0310_fa_0151v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0311",
+      "@type" : "sc:Canvas",
+      "label" : "152r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0311",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0311",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0311_fa_0152r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0311"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0311_fa_0152r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0312",
+      "@type" : "sc:Canvas",
+      "label" : "152v",
+      "width" : 1895,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0312",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0312",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0312_fa_0152v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1895,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0312"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0312_fa_0152v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0313",
+      "@type" : "sc:Canvas",
+      "label" : "153r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0313",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0313",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0313_fa_0153r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0313"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0313_fa_0153r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0314",
+      "@type" : "sc:Canvas",
+      "label" : "153v",
+      "width" : 1895,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0314",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0314",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0314_fa_0153v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1895,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0314"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0314_fa_0153v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0315",
+      "@type" : "sc:Canvas",
+      "label" : "154r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0315",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0315",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0315_fa_0154r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0315"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0315_fa_0154r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0316",
+      "@type" : "sc:Canvas",
+      "label" : "154v",
+      "width" : 1895,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0316",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0316",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0316_fa_0154v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1895,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0316"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0316_fa_0154v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0317",
+      "@type" : "sc:Canvas",
+      "label" : "155r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0317",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0317",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0317_fa_0155r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0317"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0317_fa_0155r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0318",
+      "@type" : "sc:Canvas",
+      "label" : "155v",
+      "width" : 1895,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0318",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0318",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0318_fa_0155v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1895,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0318"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0318_fa_0155v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0319",
+      "@type" : "sc:Canvas",
+      "label" : "156r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0319",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0319",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0319_fa_0156r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0319"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0319_fa_0156r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0320",
+      "@type" : "sc:Canvas",
+      "label" : "156v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0320",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0320",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0320_fa_0156v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0320"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0320_fa_0156v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0321",
+      "@type" : "sc:Canvas",
+      "label" : "157r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0321",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0321",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0321_fa_0157r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0321"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0321_fa_0157r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0322",
+      "@type" : "sc:Canvas",
+      "label" : "157v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0322",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0322",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0322_fa_0157v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0322"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0322_fa_0157v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0323",
+      "@type" : "sc:Canvas",
+      "label" : "158r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0323",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0323",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0323_fa_0158r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0323"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0323_fa_0158r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0324",
+      "@type" : "sc:Canvas",
+      "label" : "158v",
+      "width" : 1870,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0324",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0324",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0324_fa_0158v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1870,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0324"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0324_fa_0158v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0325",
+      "@type" : "sc:Canvas",
+      "label" : "159r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0325",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0325",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0325_fa_0159r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0325"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0325_fa_0159r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0326",
+      "@type" : "sc:Canvas",
+      "label" : "159v",
+      "width" : 1885,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0326",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0326",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0326_fa_0159v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1885,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0326"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0326_fa_0159v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0327",
+      "@type" : "sc:Canvas",
+      "label" : "160r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0327",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0327",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0327_fa_0160r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0327"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0327_fa_0160r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0328",
+      "@type" : "sc:Canvas",
+      "label" : "160v",
+      "width" : 1890,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0328",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0328",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0328_fa_0160v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1890,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0328"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0328_fa_0160v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0329",
+      "@type" : "sc:Canvas",
+      "label" : "161r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0329",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0329",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0329_fa_0161r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0329"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0329_fa_0161r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0330",
+      "@type" : "sc:Canvas",
+      "label" : "161v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0330",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0330",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0330_fa_0161v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0330"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0330_fa_0161v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0331",
+      "@type" : "sc:Canvas",
+      "label" : "162r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0331",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0331",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0331_fa_0162r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0331"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0331_fa_0162r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0332",
+      "@type" : "sc:Canvas",
+      "label" : "162v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0332",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0332",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0332_fa_0162v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0332"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0332_fa_0162v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0333",
+      "@type" : "sc:Canvas",
+      "label" : "163r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0333",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0333",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0333_fa_0163r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0333"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0333_fa_0163r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0334",
+      "@type" : "sc:Canvas",
+      "label" : "163v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0334",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0334",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0334_fa_0163v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0334"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0334_fa_0163v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0335",
+      "@type" : "sc:Canvas",
+      "label" : "164r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0335",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0335",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0335_fa_0164r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0335"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0335_fa_0164r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0336",
+      "@type" : "sc:Canvas",
+      "label" : "164v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0336",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0336",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0336_fa_0164v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0336"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0336_fa_0164v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0337",
+      "@type" : "sc:Canvas",
+      "label" : "165r",
+      "width" : 1945,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0337",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0337",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0337_fa_0165r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1945,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0337"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0337_fa_0165r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0338",
+      "@type" : "sc:Canvas",
+      "label" : "165v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0338",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0338",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0338_fa_0165v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0338"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0338_fa_0165v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0339",
+      "@type" : "sc:Canvas",
+      "label" : "166r",
+      "width" : 1945,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0339",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0339",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0339_fa_0166r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1945,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0339"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0339_fa_0166r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0340",
+      "@type" : "sc:Canvas",
+      "label" : "166v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0340",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0340",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0340_fa_0166v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0340"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0340_fa_0166v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0341",
+      "@type" : "sc:Canvas",
+      "label" : "167r",
+      "width" : 1945,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0341",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0341",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0341_fa_0167r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1945,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0341"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0341_fa_0167r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0342",
+      "@type" : "sc:Canvas",
+      "label" : "167v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0342",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0342",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0342_fa_0167v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0342"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0342_fa_0167v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0343",
+      "@type" : "sc:Canvas",
+      "label" : "168r",
+      "width" : 1945,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0343",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0343",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0343_fa_0168r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1945,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0343"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0343_fa_0168r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0344",
+      "@type" : "sc:Canvas",
+      "label" : "168v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0344",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0344",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0344_fa_0168v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0344"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0344_fa_0168v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0345",
+      "@type" : "sc:Canvas",
+      "label" : "169r",
+      "width" : 1902,
+      "height" : 2785,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0345",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0345",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0345_fa_0169r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1902,
+          "height" : 2785
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0345"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0345_fa_0169r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0346",
+      "@type" : "sc:Canvas",
+      "label" : "169v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0346",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0346",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0346_fa_0169v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0346"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0346_fa_0169v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0347",
+      "@type" : "sc:Canvas",
+      "label" : "170r",
+      "width" : 1902,
+      "height" : 2785,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0347",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0347",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0347_fa_0170r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1902,
+          "height" : 2785
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0347"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0347_fa_0170r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0348",
+      "@type" : "sc:Canvas",
+      "label" : "170v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0348",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0348",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0348_fa_0170v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0348"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0348_fa_0170v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0349",
+      "@type" : "sc:Canvas",
+      "label" : "171r",
+      "width" : 1905,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0349",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0349",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0349_fa_0171r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1905,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0349"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0349_fa_0171r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0350",
+      "@type" : "sc:Canvas",
+      "label" : "171v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0350",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0350",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0350_fa_0171v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0350"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0350_fa_0171v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0351",
+      "@type" : "sc:Canvas",
+      "label" : "172r",
+      "width" : 1890,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0351",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0351",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0351_fa_0172r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1890,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0351"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0351_fa_0172r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0352",
+      "@type" : "sc:Canvas",
+      "label" : "172v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0352",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0352",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0352_fa_0172v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0352"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0352_fa_0172v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0353",
+      "@type" : "sc:Canvas",
+      "label" : "173r",
+      "width" : 1875,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0353",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0353",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0353_fa_0173r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1875,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0353"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0353_fa_0173r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0354",
+      "@type" : "sc:Canvas",
+      "label" : "173v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0354",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0354",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0354_fa_0173v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0354"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0354_fa_0173v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0355",
+      "@type" : "sc:Canvas",
+      "label" : "174r",
+      "width" : 1895,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0355",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0355",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0355_fa_0174r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1895,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0355"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0355_fa_0174r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0356",
+      "@type" : "sc:Canvas",
+      "label" : "174v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0356",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0356",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0356_fa_0174v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0356"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0356_fa_0174v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0357",
+      "@type" : "sc:Canvas",
+      "label" : "175r",
+      "width" : 1875,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0357",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0357",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0357_fa_0175r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1875,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0357"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0357_fa_0175r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0358",
+      "@type" : "sc:Canvas",
+      "label" : "175v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0358",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0358",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0358_fa_0175v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0358"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0358_fa_0175v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0359",
+      "@type" : "sc:Canvas",
+      "label" : "176r",
+      "width" : 1905,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0359",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0359",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0359_fa_0176r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1905,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0359"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0359_fa_0176r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0360",
+      "@type" : "sc:Canvas",
+      "label" : "176v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0360",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0360",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0360_fa_0176v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0360"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0360_fa_0176v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0361",
+      "@type" : "sc:Canvas",
+      "label" : "177r",
+      "width" : 1905,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0361",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0361",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0361_fa_0177r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1905,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0361"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0361_fa_0177r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0362",
+      "@type" : "sc:Canvas",
+      "label" : "177v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0362",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0362",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0362_fa_0177v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0362"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0362_fa_0177v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0363",
+      "@type" : "sc:Canvas",
+      "label" : "178r",
+      "width" : 1905,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0363",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0363",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0363_fa_0178r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1905,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0363"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0363_fa_0178r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0364",
+      "@type" : "sc:Canvas",
+      "label" : "178v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0364",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0364",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0364_fa_0178v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0364"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0364_fa_0178v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0365",
+      "@type" : "sc:Canvas",
+      "label" : "179r",
+      "width" : 1905,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0365",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0365",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0365_fa_0179r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1905,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0365"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0365_fa_0179r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0366",
+      "@type" : "sc:Canvas",
+      "label" : "179v",
+      "width" : 1830,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0366",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0366",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0366_fa_0179v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1830,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0366"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0366_fa_0179v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0367",
+      "@type" : "sc:Canvas",
+      "label" : "180r",
+      "width" : 1905,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0367",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0367",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0367_fa_0180r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1905,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0367"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0367_fa_0180r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0368",
+      "@type" : "sc:Canvas",
+      "label" : "180v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0368",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0368",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0368_fa_0180v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0368"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0368_fa_0180v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0369",
+      "@type" : "sc:Canvas",
+      "label" : "181r",
+      "width" : 1900,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0369",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0369",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0369_fa_0181r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1900,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0369"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0369_fa_0181r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0370",
+      "@type" : "sc:Canvas",
+      "label" : "181v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0370",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0370",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0370_fa_0181v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0370"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0370_fa_0181v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0371",
+      "@type" : "sc:Canvas",
+      "label" : "182r",
+      "width" : 1900,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0371",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0371",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0371_fa_0182r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1900,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0371"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0371_fa_0182r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0372",
+      "@type" : "sc:Canvas",
+      "label" : "182v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0372",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0372",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0372_fa_0182v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0372"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0372_fa_0182v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0373",
+      "@type" : "sc:Canvas",
+      "label" : "183r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0373",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0373",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0373_fa_0183r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0373"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0373_fa_0183r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0374",
+      "@type" : "sc:Canvas",
+      "label" : "183v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0374",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0374",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0374_fa_0183v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0374"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0374_fa_0183v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0375",
+      "@type" : "sc:Canvas",
+      "label" : "184r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0375",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0375",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0375_fa_0184r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0375"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0375_fa_0184r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0376",
+      "@type" : "sc:Canvas",
+      "label" : "184v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0376",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0376",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0376_fa_0184v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0376"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0376_fa_0184v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0377",
+      "@type" : "sc:Canvas",
+      "label" : "185r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0377",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0377",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0377_fa_0185r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0377"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0377_fa_0185r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0378",
+      "@type" : "sc:Canvas",
+      "label" : "185v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0378",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0378",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0378_fa_0185v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0378"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0378_fa_0185v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0379",
+      "@type" : "sc:Canvas",
+      "label" : "186r",
+      "width" : 1930,
+      "height" : 2785,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0379",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0379",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0379_fa_0186r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1930,
+          "height" : 2785
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0379"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0379_fa_0186r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0380",
+      "@type" : "sc:Canvas",
+      "label" : "186v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0380",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0380",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0380_fa_0186v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0380"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0380_fa_0186v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0381",
+      "@type" : "sc:Canvas",
+      "label" : "187r",
+      "width" : 1930,
+      "height" : 2785,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0381",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0381",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0381_fa_0187r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1930,
+          "height" : 2785
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0381"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0381_fa_0187r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0382",
+      "@type" : "sc:Canvas",
+      "label" : "187v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0382",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0382",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0382_fa_0187v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0382"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0382_fa_0187v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0383",
+      "@type" : "sc:Canvas",
+      "label" : "188r",
+      "width" : 1930,
+      "height" : 2785,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0383",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0383",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0383_fa_0188r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1930,
+          "height" : 2785
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0383"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0383_fa_0188r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0384",
+      "@type" : "sc:Canvas",
+      "label" : "188v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0384",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0384",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0384_fa_0188v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0384"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0384_fa_0188v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0385",
+      "@type" : "sc:Canvas",
+      "label" : "189r",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0385",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0385",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0385_fa_0189r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0385"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0385_fa_0189r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0386",
+      "@type" : "sc:Canvas",
+      "label" : "189v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0386",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0386",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0386_fa_0189v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0386"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0386_fa_0189v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0387",
+      "@type" : "sc:Canvas",
+      "label" : "190r",
+      "width" : 1935,
+      "height" : 2785,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0387",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0387",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0387_fa_0190r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1935,
+          "height" : 2785
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0387"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0387_fa_0190r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0388",
+      "@type" : "sc:Canvas",
+      "label" : "190v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0388",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0388",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0388_fa_0190v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0388"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0388_fa_0190v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0389",
+      "@type" : "sc:Canvas",
+      "label" : "191r",
+      "width" : 1935,
+      "height" : 2785,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0389",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0389",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0389_fa_0191r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1935,
+          "height" : 2785
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0389"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0389_fa_0191r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0390",
+      "@type" : "sc:Canvas",
+      "label" : "191v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0390",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0390",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0390_fa_0191v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0390"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0390_fa_0191v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0391",
+      "@type" : "sc:Canvas",
+      "label" : "192r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0391",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0391",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0391_fa_0192r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0391"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0391_fa_0192r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0392",
+      "@type" : "sc:Canvas",
+      "label" : "192v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0392",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0392",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0392_fa_0192v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0392"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0392_fa_0192v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0393",
+      "@type" : "sc:Canvas",
+      "label" : "193r",
+      "width" : 1920,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0393",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0393",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0393_fa_0193r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1920,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0393"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0393_fa_0193r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0394",
+      "@type" : "sc:Canvas",
+      "label" : "193v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0394",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0394",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0394_fa_0193v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0394"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0394_fa_0193v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0395",
+      "@type" : "sc:Canvas",
+      "label" : "194r",
+      "width" : 1900,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0395",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0395",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0395_fa_0194r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1900,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0395"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0395_fa_0194r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0396",
+      "@type" : "sc:Canvas",
+      "label" : "194v",
+      "width" : 1825,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0396",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0396",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0396_fa_0194v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1825,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0396"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0396_fa_0194v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 98,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0397",
+      "@type" : "sc:Canvas",
+      "label" : "195r",
+      "width" : 1900,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0397",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0397",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0397_fa_0195r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1900,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0397"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0397_fa_0195r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0398",
+      "@type" : "sc:Canvas",
+      "label" : "195v",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0398",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0398",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0398_fa_0195v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0398"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0398_fa_0195v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0399",
+      "@type" : "sc:Canvas",
+      "label" : "196r",
+      "width" : 1900,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0399",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0399",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0399_fa_0196r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1900,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0399"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0399_fa_0196r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0400",
+      "@type" : "sc:Canvas",
+      "label" : "196v",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0400",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0400",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0400_fa_0196v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0400"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0400_fa_0196v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0401",
+      "@type" : "sc:Canvas",
+      "label" : "197r",
+      "width" : 1900,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0401",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0401",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0401_fa_0197r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1900,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0401"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0401_fa_0197r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0402",
+      "@type" : "sc:Canvas",
+      "label" : "197v",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0402",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0402",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0402_fa_0197v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0402"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0402_fa_0197v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0403",
+      "@type" : "sc:Canvas",
+      "label" : "198r",
+      "width" : 1930,
+      "height" : 2785,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0403",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0403",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0403_fa_0198r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1930,
+          "height" : 2785
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0403"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0403_fa_0198r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0404",
+      "@type" : "sc:Canvas",
+      "label" : "198v",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0404",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0404",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0404_fa_0198v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0404"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0404_fa_0198v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0405",
+      "@type" : "sc:Canvas",
+      "label" : "199r",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0405",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0405",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0405_fa_0199r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0405"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0405_fa_0199r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0406",
+      "@type" : "sc:Canvas",
+      "label" : "199v",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0406",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0406",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0406_fa_0199v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0406"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0406_fa_0199v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0407",
+      "@type" : "sc:Canvas",
+      "label" : "200r",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0407",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0407",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0407_fa_0200r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0407"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0407_fa_0200r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0408",
+      "@type" : "sc:Canvas",
+      "label" : "200v",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0408",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0408",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0408_fa_0200v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0408"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0408_fa_0200v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0409",
+      "@type" : "sc:Canvas",
+      "label" : "201r",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0409",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0409",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0409_fa_0201r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0409"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0409_fa_0201r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0410",
+      "@type" : "sc:Canvas",
+      "label" : "201v",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0410",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0410",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0410_fa_0201v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0410"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0410_fa_0201v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0411",
+      "@type" : "sc:Canvas",
+      "label" : "202r",
+      "width" : 1900,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0411",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0411",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0411_fa_0202r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1900,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0411"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0411_fa_0202r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0412",
+      "@type" : "sc:Canvas",
+      "label" : "202v",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0412",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0412",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0412_fa_0202v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0412"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0412_fa_0202v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0413",
+      "@type" : "sc:Canvas",
+      "label" : "203r",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0413",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0413",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0413_fa_0203r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0413"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0413_fa_0203r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0414",
+      "@type" : "sc:Canvas",
+      "label" : "203v",
+      "width" : 1790,
+      "height" : 2775,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0414",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0414",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0414_fa_0203v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1790,
+          "height" : 2775
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0414"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0414_fa_0203v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 96,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0415",
+      "@type" : "sc:Canvas",
+      "label" : "204r",
+      "width" : 1890,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0415",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0415",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0415_fa_0204r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1890,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0415"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0415_fa_0204r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0416",
+      "@type" : "sc:Canvas",
+      "label" : "204v",
+      "width" : 1745,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0416",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0416",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0416_fa_0204v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1745,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0416"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0416_fa_0204v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0417",
+      "@type" : "sc:Canvas",
+      "label" : "205r",
+      "width" : 1855,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0417",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0417",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0417_fa_0205r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1855,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0417"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0417_fa_0205r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0418",
+      "@type" : "sc:Canvas",
+      "label" : "205v",
+      "width" : 1745,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0418",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0418",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0418_fa_0205v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1745,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0418"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0418_fa_0205v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0419",
+      "@type" : "sc:Canvas",
+      "label" : "206r",
+      "width" : 1890,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0419",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0419",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0419_fa_0206r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1890,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0419"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0419_fa_0206r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0420",
+      "@type" : "sc:Canvas",
+      "label" : "206v",
+      "width" : 1745,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0420",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0420",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0420_fa_0206v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1745,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0420"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0420_fa_0206v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0421",
+      "@type" : "sc:Canvas",
+      "label" : "207r",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0421",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0421",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0421_fa_0207r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0421"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0421_fa_0207r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0422",
+      "@type" : "sc:Canvas",
+      "label" : "207v",
+      "width" : 1745,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0422",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0422",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0422_fa_0207v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1745,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0422"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0422_fa_0207v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0423",
+      "@type" : "sc:Canvas",
+      "label" : "208r",
+      "width" : 1890,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0423",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0423",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0423_fa_0208r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1890,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0423"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0423_fa_0208r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0424",
+      "@type" : "sc:Canvas",
+      "label" : "208v",
+      "width" : 1745,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0424",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0424",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0424_fa_0208v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1745,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0424"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0424_fa_0208v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0425",
+      "@type" : "sc:Canvas",
+      "label" : "209r",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0425",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0425",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0425_fa_0209r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0425"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0425_fa_0209r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0426",
+      "@type" : "sc:Canvas",
+      "label" : "209v",
+      "width" : 1745,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0426",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0426",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0426_fa_0209v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1745,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0426"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0426_fa_0209v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0427",
+      "@type" : "sc:Canvas",
+      "label" : "210r",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0427",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0427",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0427_fa_0210r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0427"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0427_fa_0210r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0428",
+      "@type" : "sc:Canvas",
+      "label" : "210v",
+      "width" : 1745,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0428",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0428",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0428_fa_0210v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1745,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0428"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0428_fa_0210v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0429",
+      "@type" : "sc:Canvas",
+      "label" : "211r",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0429",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0429",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0429_fa_0211r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0429"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0429_fa_0211r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0430",
+      "@type" : "sc:Canvas",
+      "label" : "211v",
+      "width" : 1745,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0430",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0430",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0430_fa_0211v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1745,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0430"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0430_fa_0211v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0431",
+      "@type" : "sc:Canvas",
+      "label" : "212r",
+      "width" : 1865,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0431",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0431",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0431_fa_0212r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1865,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0431"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0431_fa_0212r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0432",
+      "@type" : "sc:Canvas",
+      "label" : "212v",
+      "width" : 1745,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0432",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0432",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0432_fa_0212v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1745,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0432"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0432_fa_0212v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0433",
+      "@type" : "sc:Canvas",
+      "label" : "213r",
+      "width" : 1835,
+      "height" : 2778,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0433",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0433",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0433_fa_0213r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1835,
+          "height" : 2778
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0433"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0433_fa_0213r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 99,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0434",
+      "@type" : "sc:Canvas",
+      "label" : "213v",
+      "width" : 1727,
+      "height" : 2771,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0434",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0434",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0434_fa_0213v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1727,
+          "height" : 2771
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0434"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0434_fa_0213v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 93,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0435",
+      "@type" : "sc:Canvas",
+      "label" : "214r",
+      "width" : 1855,
+      "height" : 2780,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0435",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0435",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0435_fa_0214r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1855,
+          "height" : 2780
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0435"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0435_fa_0214r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 100,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0436",
+      "@type" : "sc:Canvas",
+      "label" : "214v",
+      "width" : 1727,
+      "height" : 2771,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0436",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0436",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0436_fa_0214v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1727,
+          "height" : 2771
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0436"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0436_fa_0214v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 93,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0437",
+      "@type" : "sc:Canvas",
+      "label" : "215r",
+      "width" : 1875,
+      "height" : 2781,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0437",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0437",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0437_fa_0215r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1875,
+          "height" : 2781
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0437"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0437_fa_0215r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0438",
+      "@type" : "sc:Canvas",
+      "label" : "215v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0438",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0438",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0438_fa_0215v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0438"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0438_fa_0215v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0439",
+      "@type" : "sc:Canvas",
+      "label" : "216r",
+      "width" : 1900,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0439",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0439",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0439_fa_0216r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1900,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0439"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0439_fa_0216r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0440",
+      "@type" : "sc:Canvas",
+      "label" : "216v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0440",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0440",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0440_fa_0216v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0440"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0440_fa_0216v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0441",
+      "@type" : "sc:Canvas",
+      "label" : "217r",
+      "width" : 1890,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0441",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0441",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0441_fa_0217r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1890,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0441"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0441_fa_0217r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0442",
+      "@type" : "sc:Canvas",
+      "label" : "217v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0442",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0442",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0442_fa_0217v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0442"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0442_fa_0217v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0443",
+      "@type" : "sc:Canvas",
+      "label" : "218r",
+      "width" : 1900,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0443",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0443",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0443_fa_0218r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1900,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0443"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0443_fa_0218r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0444",
+      "@type" : "sc:Canvas",
+      "label" : "218v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0444",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0444",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0444_fa_0218v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0444"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0444_fa_0218v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0445",
+      "@type" : "sc:Canvas",
+      "label" : "219r",
+      "width" : 1880,
+      "height" : 2782,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0445",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0445",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0445_fa_0219r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1880,
+          "height" : 2782
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0445"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0445_fa_0219r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 101,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0446",
+      "@type" : "sc:Canvas",
+      "label" : "219v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0446",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0446",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0446_fa_0219v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0446"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0446_fa_0219v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0447",
+      "@type" : "sc:Canvas",
+      "label" : "220r",
+      "width" : 1895,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0447",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0447",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0447_fa_0220r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1895,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0447"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0447_fa_0220r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0448",
+      "@type" : "sc:Canvas",
+      "label" : "220v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0448",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0448",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0448_fa_0220v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0448"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0448_fa_0220v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0449",
+      "@type" : "sc:Canvas",
+      "label" : "221r",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0449",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0449",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0449_fa_0221r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0449"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0449_fa_0221r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0450",
+      "@type" : "sc:Canvas",
+      "label" : "221v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0450",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0450",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0450_fa_0221v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0450"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0450_fa_0221v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0451",
+      "@type" : "sc:Canvas",
+      "label" : "222r",
+      "width" : 1945,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0451",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0451",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0451_fa_0222r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1945,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0451"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0451_fa_0222r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0452",
+      "@type" : "sc:Canvas",
+      "label" : "222v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0452",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0452",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0452_fa_0222v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0452"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0452_fa_0222v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0453",
+      "@type" : "sc:Canvas",
+      "label" : "223r",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0453",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0453",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0453_fa_0223r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0453"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0453_fa_0223r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0454",
+      "@type" : "sc:Canvas",
+      "label" : "223v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0454",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0454",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0454_fa_0223v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0454"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0454_fa_0223v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0455",
+      "@type" : "sc:Canvas",
+      "label" : "224r",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0455",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0455",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0455_fa_0224r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0455"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0455_fa_0224r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0456",
+      "@type" : "sc:Canvas",
+      "label" : "224v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0456",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0456",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0456_fa_0224v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0456"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0456_fa_0224v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0457",
+      "@type" : "sc:Canvas",
+      "label" : "225r",
+      "width" : 1895,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0457",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0457",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0457_fa_0225r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1895,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0457"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0457_fa_0225r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0458",
+      "@type" : "sc:Canvas",
+      "label" : "225v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0458",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0458",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0458_fa_0225v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0458"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0458_fa_0225v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0459",
+      "@type" : "sc:Canvas",
+      "label" : "226r",
+      "width" : 1895,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0459",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0459",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0459_fa_0226r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1895,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0459"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0459_fa_0226r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0460",
+      "@type" : "sc:Canvas",
+      "label" : "226v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0460",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0460",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0460_fa_0226v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0460"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0460_fa_0226v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0461",
+      "@type" : "sc:Canvas",
+      "label" : "227r",
+      "width" : 1925,
+      "height" : 2785,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0461",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0461",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0461_fa_0227r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1925,
+          "height" : 2785
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0461"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0461_fa_0227r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0462",
+      "@type" : "sc:Canvas",
+      "label" : "227v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0462",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0462",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0462_fa_0227v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0462"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0462_fa_0227v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0463",
+      "@type" : "sc:Canvas",
+      "label" : "228r",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0463",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0463",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0463_fa_0228r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0463"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0463_fa_0228r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0464",
+      "@type" : "sc:Canvas",
+      "label" : "228v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0464",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0464",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0464_fa_0228v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0464"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0464_fa_0228v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0465",
+      "@type" : "sc:Canvas",
+      "label" : "229r",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0465",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0465",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0465_fa_0229r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0465"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0465_fa_0229r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0466",
+      "@type" : "sc:Canvas",
+      "label" : "229v",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0466",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0466",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0466_fa_0229v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0466"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0466_fa_0229v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0467",
+      "@type" : "sc:Canvas",
+      "label" : "230r",
+      "width" : 1925,
+      "height" : 2785,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0467",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0467",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0467_fa_0230r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1925,
+          "height" : 2785
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0467"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0467_fa_0230r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0468",
+      "@type" : "sc:Canvas",
+      "label" : "230v",
+      "width" : 1917,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0468",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0468",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0468_fa_0230v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1917,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0468"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0468_fa_0230v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0469",
+      "@type" : "sc:Canvas",
+      "label" : "230r.[01.fx.0000]",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0469",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0469",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0469_fa_0230r.%5B01.fx.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0469"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0469_fa_0230r.%5B01.fx.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0470",
+      "@type" : "sc:Canvas",
+      "label" : "230v.[01.fx.0000]",
+      "width" : 1897,
+      "height" : 2785,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0470",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0470",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0470_fa_0230v.%5B01.fx.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1897,
+          "height" : 2785
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0470"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0470_fa_0230v.%5B01.fx.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0471",
+      "@type" : "sc:Canvas",
+      "label" : "231r",
+      "width" : 1905,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0471",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0471",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0471_fa_0231r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1905,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0471"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0471_fa_0231r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0472",
+      "@type" : "sc:Canvas",
+      "label" : "231v",
+      "width" : 1807,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0472",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0472",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0472_fa_0231v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1807,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0472"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0472_fa_0231v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0473",
+      "@type" : "sc:Canvas",
+      "label" : "232r",
+      "width" : 1895,
+      "height" : 2783,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0473",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0473",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0473_fa_0232r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1895,
+          "height" : 2783
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0473"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0473_fa_0232r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0474",
+      "@type" : "sc:Canvas",
+      "label" : "232v",
+      "width" : 1807,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0474",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0474",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0474_fa_0232v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1807,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0474"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0474_fa_0232v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0475",
+      "@type" : "sc:Canvas",
+      "label" : "233r",
+      "width" : 1910,
+      "height" : 2784,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0475",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0475",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0475_fa_0233r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1910,
+          "height" : 2784
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0475"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0475_fa_0233r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 102,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0476",
+      "@type" : "sc:Canvas",
+      "label" : "233v",
+      "width" : 1807,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0476",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0476",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0476_fa_0233v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1807,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0476"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0476_fa_0233v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0477",
+      "@type" : "sc:Canvas",
+      "label" : "234r",
+      "width" : 1925,
+      "height" : 2785,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0477",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0477",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0477_fa_0234r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1925,
+          "height" : 2785
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0477"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0477_fa_0234r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 103,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0478",
+      "@type" : "sc:Canvas",
+      "label" : "234v",
+      "width" : 1807,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0478",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0478",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0478_fa_0234v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1807,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0478"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0478_fa_0234v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0479",
+      "@type" : "sc:Canvas",
+      "label" : "234r.[01.fx.0000]",
+      "width" : 1740,
+      "height" : 2772,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0479",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0479",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0479_fa_0234r.%5B01.fx.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1740,
+          "height" : 2772
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0479"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0479_fa_0234r.%5B01.fx.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 94,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0480",
+      "@type" : "sc:Canvas",
+      "label" : "234v.[01.fx.0000]",
+      "width" : 1807,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0480",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0480",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0480_fa_0234v.%5B01.fx.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1807,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0480"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0480_fa_0234v.%5B01.fx.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0481",
+      "@type" : "sc:Canvas",
+      "label" : "1r",
+      "width" : 1940,
+      "height" : 2786,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0481",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0481",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0481_sy_0001r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2786
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0481"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0481_sy_0001r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0482",
+      "@type" : "sc:Canvas",
+      "label" : "1v",
+      "width" : 1807,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0482",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0482",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0482_sy_0001v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1807,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0482"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0482_sy_0001v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0483",
+      "@type" : "sc:Canvas",
+      "label" : "2r",
+      "width" : 1960,
+      "height" : 2787,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0483",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0483",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0483_sy_0002r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1960,
+          "height" : 2787
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0483"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0483_sy_0002r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 105,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0484",
+      "@type" : "sc:Canvas",
+      "label" : "2v",
+      "width" : 1807,
+      "height" : 2776,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0484",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0484",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0484_sy_0002v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1807,
+          "height" : 2776
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0484"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0484_sy_0002v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 97,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0485",
+      "@type" : "sc:Canvas",
+      "label" : "risguardia.posteriore",
+      "width" : 2040,
+      "height" : 2918,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0485",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0485",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0485_ye_risguardia.posteriore.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2040,
+          "height" : 2918
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0485"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0485_ye_risguardia.posteriore.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 104,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0486",
+      "@type" : "sc:Canvas",
+      "label" : "dorso",
+      "width" : 875,
+      "height" : 2741,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0486",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0486",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0486_yh_dorso.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 875,
+          "height" : 2741
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0486"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0486_yh_dorso.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 47,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0487",
+      "@type" : "sc:Canvas",
+      "label" : "taglio.centrale",
+      "width" : 815,
+      "height" : 2762,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0487",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0487",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0487_yl_taglio.centrale.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 815,
+          "height" : 2762
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0487"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0487_yl_taglio.centrale.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 44,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0488",
+      "@type" : "sc:Canvas",
+      "label" : "taglio.inferiore",
+      "width" : 905,
+      "height" : 2238,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0488",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0488",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0488_yn_taglio.inferiore.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 905,
+          "height" : 2238
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0488"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0488_yn_taglio.inferiore.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 60,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0489",
+      "@type" : "sc:Canvas",
+      "label" : "taglio.superiore",
+      "width" : 905,
+      "height" : 2238,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0489",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0489",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0489_yp_taglio.superiore.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 905,
+          "height" : 2238
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0489"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0489_yp_taglio.superiore.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 60,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0490",
+      "@type" : "sc:Canvas",
+      "label" : "piatto.posteriore",
+      "width" : 2145,
+      "height" : 2920,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0490",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0490",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0490_za_piatto.posteriore.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2145,
+          "height" : 2920
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0490"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0490_za_piatto.posteriore.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 110,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0491",
+      "@type" : "sc:Canvas",
+      "label" : "colorchecker",
+      "width" : 1990,
+      "height" : 3129,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0491",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0491",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0491_zx_colorchecker.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1990,
+          "height" : 3129
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0491"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0491_zx_colorchecker.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 95,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0492",
+      "@type" : "sc:Canvas",
+      "label" : "scala.millimetrica",
+      "width" : 2615,
+      "height" : 3478,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/anno0492",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/res/img0492",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Ott.gr.85/Ott.gr.85_0492_zz_scala.millimetrica.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2615,
+          "height" : 3478
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0492"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Ott.gr.85/thumb/Ott.gr.85_0492_zz_scala.millimetrica.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    } ],
+    "viewingDirection" : "left-to-right",
+    "viewingHint" : "paged"
+  } ],
+  "structures" : [ {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "@type" : "sc:Range",
+    "label" : "Miscellanea homiletica; sec. X-XI",
+    "ranges" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-0", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-1", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-2", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-3", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-4", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-5", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-6", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-7", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-8", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-9", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-10", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-11", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-12", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-13", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-14", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-15", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-16", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-17", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-18", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-19", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-20", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-21", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-22", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-23", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-24", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-25", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-26", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-27", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-28", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-29", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-30", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-31", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-32", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-33", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-34", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-35", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-36", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-37", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-38", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-39", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-40", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-41", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-42", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-43" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-0",
+    "@type" : "sc:Range",
+    "label" : "Legatura",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0001" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-1",
+    "@type" : "sc:Range",
+    "label" : "1r-v Leontius Constantinopolitanus: In nativitatem Christi (fragmentum)",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0009", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0010" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-2",
+    "@type" : "sc:Range",
+    "label" : "2r-7v Athanasius, s., patriarca di Alessandria: Sermo de descriptione Deiparae",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0011", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0012", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0013", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0014", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0015", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0016", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0017", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0018", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0019", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0020", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0021", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0022" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-3",
+    "@type" : "sc:Range",
+    "label" : "7v-17v Gregorius Nyssenus, s.: Oratio in diem natalem Christi",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0022", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0023", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0024", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0025", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0026", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0027", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0028", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0029", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0030", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0031", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0032", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0033", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0034", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0035", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0036", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0037", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0038", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0039", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0040", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0041", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0042" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-4",
+    "@type" : "sc:Range",
+    "label" : "18r-21v Proclus, s., arciv. di Costantinopoli: In sanctum Stephanum homilia",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0043", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0044", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0045", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0046", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0047", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0048", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0049", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0050" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-5",
+    "@type" : "sc:Range",
+    "label" : "21v-24v Iohannes Euboeensis: Homilia in sanctos Innocentes",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0050", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0051", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0052", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0053", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0054", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0055", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0056" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-6",
+    "@type" : "sc:Range",
+    "label" : "25r-38r Gregorius Nyssenus, s.: In Basilium fratrem",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0057", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0058", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0059", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0060", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0061", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0062", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0063", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0064", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0065", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0066", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0067", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0068", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0069", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0070", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0071", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0072", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0073", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0074", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0075", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0076", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0077", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0078", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0079", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0080", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0081", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0082", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0083" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-7",
+    "@type" : "sc:Range",
+    "label" : "38r-45v Gregorius Nazianzenus, s.: In sancta lumina",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0083", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0084", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0085", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0086", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0087", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0088", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0089", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0090", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0091", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0092", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0093", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0094", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0095", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0096", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0097", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0098" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-8",
+    "@type" : "sc:Range",
+    "label" : "46r-60v Gregorius Nazianzenus, s.: In sanctum baptisma",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0099", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0100", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0101", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0102", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0103", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0104", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0105", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0106", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0107", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0108", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0109", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0110", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0111", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0112", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0113", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0114", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0115", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0116", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0117", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0118", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0119", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0120", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0121", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0122", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0123", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0124", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0125", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0126", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0127", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0128" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-9",
+    "@type" : "sc:Range",
+    "label" : "61r-v Iohannes Chrysostomus, s., patriarca di Costantinopoli: De baptismo Christi",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0129", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0130" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-10",
+    "@type" : "sc:Range",
+    "label" : "61v-66v Gregorius Antiochenus, vesc. di Antiochia: Homilia II In s. Theophania",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0130", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0131", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0132", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0133", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0134", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0135", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0136", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0137", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0138", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0139", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0140" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-11",
+    "@type" : "sc:Range",
+    "label" : "67r-72r Amphilochius, s., vesc. di Iconium: In occursum Domini",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0141", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0142", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0143", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0144", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0145", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0146", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0147", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0148", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0149", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0150", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0151" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-12",
+    "@type" : "sc:Range",
+    "label" : "72r-76v Timotheus Hierosolymitanus: Sermo in Crucem et Transfigurationem",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0151", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0152", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0153", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0154", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0155", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0156", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0157", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0158", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0159", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0160" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-13",
+    "@type" : "sc:Range",
+    "label" : "76v-89v Methodius, s., vesc. di Olympus: Sermo de Simeone et Anna",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0160", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0161", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0162", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0163", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0164", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0165", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0166", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0167", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0168", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0169", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0170", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0171", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0172", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0173", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0174", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0175", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0176", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0177", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0178", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0179", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0180", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0181", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0182", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0183", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0184", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0185", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0186" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-14",
+    "@type" : "sc:Range",
+    "label" : "89v-93v Cyrillus, s., patriarca di Alessandria: Commentarii in Lucam. Homiliae III et IV",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0186", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0187", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0188", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0189", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0190", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0191", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0192", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0193", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0194" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-15",
+    "@type" : "sc:Range",
+    "label" : "93v-97v Hesychius Hierosolymitanus: Homiliae in Hypapanten I et II",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0194", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0195", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0196", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0197", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0198", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0199", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0200", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0201", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0202" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-16",
+    "@type" : "sc:Range",
+    "label" : "97v-100r Eusebius Alexandrinus: In secundum adventum Domini",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0202", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0203", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0204", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0205", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0206", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0207" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-17",
+    "@type" : "sc:Range",
+    "label" : "100r-105r Gregorius Nyssenus, s.: De sancto Theodoro",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0207", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0208", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0209", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0210", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0211", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0212", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0213", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0214", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0215", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0216", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0217" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-18",
+    "@type" : "sc:Range",
+    "label" : "105r-113v Proclus, s., arciv. di Costantinopoli: Laudatio de genitricis Mariae",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0217", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0218", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0219", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0220", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0221", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0222", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0223", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0224", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0225", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0226", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0227", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0228", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0229", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0230", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0231", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0232", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0233", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0234" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-19",
+    "@type" : "sc:Range",
+    "label" : "114r-117v Iohannes Chrysostomus, s., patriarca di Costantinopoli. Opere spurie e dubbie: In Annuntiationem ss. Deiparae",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0235", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0236", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0237", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0238", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0239", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0240", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0241", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0242" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-20",
+    "@type" : "sc:Range",
+    "label" : "117v-120r Iohannes Chrysostomus, s., patriarca di Costantinopoli. Opere spurie e dubbie: In Annuntiationem beatae virginis",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0242", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0243", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0244", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0245", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0246", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0247" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-21",
+    "@type" : "sc:Range",
+    "label" : "120r-129r Andreas Cretensis, s., arciv. di Gortyna: Homilia in annuntiationem beatae Mariae",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0247", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0248", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0249", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0250", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0251", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0252", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0253", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0254", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0255", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0256", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0257", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0258", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0259", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0260", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0261", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0262", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0263", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0264", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0265" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-22",
+    "@type" : "sc:Range",
+    "label" : "129v-132v Gregorius Thaumaturgus, s., vesc. di Neocesarea: Homilia I in Annuntiationem virginis Mariae",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0266", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0267", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0268", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0269", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0270", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0271", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0272" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-23",
+    "@type" : "sc:Range",
+    "label" : "132v-140v Iohannes Chrysostomus, s., patriarca di Costantinopoli: De petitione matris filiorum Zebedaei",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0272", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0273", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0274", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0275", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0276", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0277", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0278", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0279", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0280", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0281", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0282", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0283", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0284", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0285", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0286", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0287", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0288" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-24",
+    "@type" : "sc:Range",
+    "label" : "140v-151r Andreas Cretensis, s., arciv. di Gortyna: Homilia in Lazarum quatriduanum",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0288", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0289", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0290", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0291", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0292", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0293", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0294", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0295", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0296", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0297", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0298", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0299", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0300", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0301", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0302", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0303", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0304", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0305", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0306", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0307", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0308", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0309" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-25",
+    "@type" : "sc:Range",
+    "label" : "151r-153v Amphilochius, s., vesc. di Iconium: In Lazarum",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0309", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0310", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0311", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0312", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0313", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0314" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-26",
+    "@type" : "sc:Range",
+    "label" : "153v-157r Iohannes Chrysostomus, s., patriarca di Costantinopoli: In quatriduanum Lazarum",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0314", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0315", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0316", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0317", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0318", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0319", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0320", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0321" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-27",
+    "@type" : "sc:Range",
+    "label" : "157r-162v Iohannes Chrysostomus, s., patriarca di Costantinopoli. Opere spurie e dubbie: In ramos palmarum",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0321", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0322", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0323", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0324", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0325", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0326", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0327", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0328", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0329", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0330", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0331", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0332" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-28",
+    "@type" : "sc:Range",
+    "label" : "162v-174r Andreas Cretensis, s., arciv. di Gortyna: In ramos palmarum",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0332", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0333", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0334", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0335", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0336", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0337", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0338", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0339", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0340", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0341", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0342", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0343", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0344", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0345", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0346", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0347", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0348", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0349", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0350", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0351", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0352", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0353", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0354", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0355" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-29",
+    "@type" : "sc:Range",
+    "label" : "174r-176r Proclus, s., arciv. di Costantinopoli: In ramos Palmarum",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0355", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0356", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0357", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0358", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0359" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-30",
+    "@type" : "sc:Range",
+    "label" : "176r-178v Iohannes Chrysostomus, s., patriarca di Costantinopoli. Opere spurie e dubbie: In illud: Collegerunt Judaei",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0359", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0360", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0361", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0362", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0363", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0364" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-31",
+    "@type" : "sc:Range",
+    "label" : "178v-182v Iohannes Chrysostomus, s., patriarca di Costantinopoli. Opere spurie e dubbie: In Illud: Exeuntes Pharisaei",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0364", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0365", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0366", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0367", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0368", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0369", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0370", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0371", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0372" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-32",
+    "@type" : "sc:Range",
+    "label" : "182v-184r Iohannes Chrysostomus, s., patriarca di Costantinopoli. Opere spurie e dubbie: In meretricem et in pharisaeum",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0372", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0373", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0374", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0375" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-33",
+    "@type" : "sc:Range",
+    "label" : "184r-188r Severianus Gabalensis, s.: In meretricem et Pharisaeum",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0375", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0376", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0377", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0378", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0379", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0380", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0381", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0382", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0383" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-34",
+    "@type" : "sc:Range",
+    "label" : "188r-196r Iohannes Chrysostomus, s., patriarca di Costantinopoli: De proditione Judae homilae I et II",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0383", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0384", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0385", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0386", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0387", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0388", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0389", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0390", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0391", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0392", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0393", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0394", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0395", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0396", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0397", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0398", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0399" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-35",
+    "@type" : "sc:Range",
+    "label" : "196r-199r Severianus Gabalensis, s.: Homilia de lotione pedum",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0399", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0400", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0401", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0402", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0403", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0404", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0405" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-36",
+    "@type" : "sc:Range",
+    "label" : "199r-207r Iohannes Chrysostomus, s., patriarca di Costantinopoli. Opere spurie e dubbie: In Illud: Pater si possibile est",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0405", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0406", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0407", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0408", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0409", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0410", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0411", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0412", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0413", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0414", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0415", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0416", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0417", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0418", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0419", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0420", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0421" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-37",
+    "@type" : "sc:Range",
+    "label" : "207r-210r Ephraem Syrus, s.: De passione Salvatoris",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0421", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0422", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0423", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0424", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0425", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0426", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0427" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-38",
+    "@type" : "sc:Range",
+    "label" : "210r-214v Iohannes Chrysostomus, s., patriarca di Costantinopoli. Opere spurie e dubbie: In sancta et magna parasceve",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0427", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0428", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0429", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0430", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0431", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0432", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0433", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0434", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0435", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0436" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-39",
+    "@type" : "sc:Range",
+    "label" : "214v-220r Iohannes Chrysostomus, s., patriarca di Costantinopoli. Opere spurie e dubbie: In vivificam sepulturam et triduanam resurrectionem Christi",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0436", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0437", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0438", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0439", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0440", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0441", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0442", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0443", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0444", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0445", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0446", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0447" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-40",
+    "@type" : "sc:Range",
+    "label" : "220v-230r Epiphanius, s., vesc. di Costanza in Cipro: Homilia in divini corporis sepulturam",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0448", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0449", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0450", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0451", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0452", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0453", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0454", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0455", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0456", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0457", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0458", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0459", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0460", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0461", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0462", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0463", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0464", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0465", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0466", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0467" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-41",
+    "@type" : "sc:Range",
+    "label" : "230r-v Gregorius Nazianzenus, s.: In sanctum Pascha et in tarditatem (fragmenta)",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0467", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0468" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-42",
+    "@type" : "sc:Range",
+    "label" : "231r-234v Gregorius Nazianzenus, s.: In sanctum Pascha (fragmenta)",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0471", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0472", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0473", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0474", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0475", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0476", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0477", "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0478" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0-43",
+    "@type" : "sc:Range",
+    "label" : "Legatura",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Ott.gr.85/canvas/p0490" ]
+  } ],
+  "seeAlso" : [ "https://digi.vatlib.it/mss/detail/Ott.gr.85" ]
+}

--- a/spec/fixtures/manifests/MSS_Vat.lat.3195.json
+++ b/spec/fixtures/manifests/MSS_Vat.lat.3195.json
@@ -1,0 +1,9919 @@
+{
+  "@context" : "http://iiif.io/api/presentation/2/context.json",
+  "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/manifest.json",
+  "@type" : "sc:Manifest",
+  "metadata" : [ {
+    "label" : "Shelfmark",
+    "value" : "Vat.lat.3195"
+  }, {
+    "label" : "Author",
+    "value" : [ "Petrarca, Francesco, 1304-1374" ]
+  }, {
+    "label" : "Title",
+    "value" : [ "Rerum vulgarium fragmenta" ]
+  }, {
+    "label" : "Date",
+    "value" : [ "1366-1374" ]
+  } ],
+  "label" : "Vat.lat.3195",
+  "description" : "",
+  "thumbnail" : {
+    "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/cover/cover.jpg",
+    "@type" : "dctypes:Image",
+    "format" : "image/jpeg"
+  },
+  "viewingDirection" : "left-to-right",
+  "viewingHint" : "paged",
+  "attribution" : "Images Copyright Biblioteca Apostolica Vaticana",
+  "logo" : "https://digi.vatlib.it/resource/img/i/DVL_logo.jpg",
+  "sequences" : [ {
+    "@type" : "sc:Sequence",
+    "canvases" : [ {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0001",
+      "@type" : "sc:Canvas",
+      "label" : "piatto.anteriore",
+      "width" : 1997,
+      "height" : 2662,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0001",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0001",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0001_al_piatto.anteriore.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1997,
+          "height" : 2662
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0001"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0001_al_piatto.anteriore.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0002",
+      "@type" : "sc:Canvas",
+      "label" : "risguardia.anteriore",
+      "width" : 1922,
+      "height" : 2560,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0002",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0002",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0002_ba_risguardia.anteriore.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1922,
+          "height" : 2560
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0002"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0002_ba_risguardia.anteriore.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0003",
+      "@type" : "sc:Canvas",
+      "label" : "1r",
+      "width" : 1902,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0003",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0003",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0003_cy_0001r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1902,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0003"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0003_cy_0001r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0004",
+      "@type" : "sc:Canvas",
+      "label" : "1v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0004",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0004",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0004_cy_0001v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0004"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0004_cy_0001v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0005",
+      "@type" : "sc:Canvas",
+      "label" : "1v.[02.wl.0000]",
+      "width" : 1945,
+      "height" : 2701,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0005",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0005",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0005_cy_0001v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1945,
+          "height" : 2701
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0005"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0005_cy_0001v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0006",
+      "@type" : "sc:Canvas",
+      "label" : "2r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0006",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0006",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0006_cy_0002r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0006"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0006_cy_0002r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0007",
+      "@type" : "sc:Canvas",
+      "label" : "2r.[02.wl.0000]",
+      "width" : 2017,
+      "height" : 2712,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0007",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0007",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0007_cy_0002r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2017,
+          "height" : 2712
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0007"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0007_cy_0002r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 111,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0008",
+      "@type" : "sc:Canvas",
+      "label" : "2v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0008",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0008",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0008_cy_0002v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0008"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0008_cy_0002v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0009",
+      "@type" : "sc:Canvas",
+      "label" : "2v.[02.wl.0000]",
+      "width" : 2000,
+      "height" : 2737,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0009",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0009",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0009_cy_0002v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2000,
+          "height" : 2737
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0009"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0009_cy_0002v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0010",
+      "@type" : "sc:Canvas",
+      "label" : "3r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0010",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0010",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0010_cy_0003r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0010"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0010_cy_0003r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0011",
+      "@type" : "sc:Canvas",
+      "label" : "3r.[02.wl.0000]",
+      "width" : 1959,
+      "height" : 2711,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0011",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0011",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0011_cy_0003r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1959,
+          "height" : 2711
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0011"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0011_cy_0003r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0012",
+      "@type" : "sc:Canvas",
+      "label" : "3v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0012",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0012",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0012_cy_0003v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0012"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0012_cy_0003v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0013",
+      "@type" : "sc:Canvas",
+      "label" : "3v.[02.wl.0000]",
+      "width" : 2008,
+      "height" : 2704,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0013",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0013",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0013_cy_0003v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2008,
+          "height" : 2704
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0013"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0013_cy_0003v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 111,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0014",
+      "@type" : "sc:Canvas",
+      "label" : "1r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0014",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0014",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0014_fa_0001r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0014"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0014_fa_0001r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0015",
+      "@type" : "sc:Canvas",
+      "label" : "1r.[02.wl.0000]",
+      "width" : 2011,
+      "height" : 2698,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0015",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0015",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0015_fa_0001r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2011,
+          "height" : 2698
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0015"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0015_fa_0001r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 111,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0016",
+      "@type" : "sc:Canvas",
+      "label" : "1v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0016",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0016",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0016_fa_0001v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0016"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0016_fa_0001v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0017",
+      "@type" : "sc:Canvas",
+      "label" : "1v.[02.wl.0000]",
+      "width" : 1932,
+      "height" : 2710,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0017",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0017",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0017_fa_0001v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1932,
+          "height" : 2710
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0017"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0017_fa_0001v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0018",
+      "@type" : "sc:Canvas",
+      "label" : "2r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0018",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0018",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0018_fa_0002r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0018"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0018_fa_0002r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0019",
+      "@type" : "sc:Canvas",
+      "label" : "2r.[02.wl.0000]",
+      "width" : 2015,
+      "height" : 2716,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0019",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0019",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0019_fa_0002r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2015,
+          "height" : 2716
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0019"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0019_fa_0002r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 111,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0020",
+      "@type" : "sc:Canvas",
+      "label" : "2v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0020",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0020",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0020_fa_0002v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0020"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0020_fa_0002v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0021",
+      "@type" : "sc:Canvas",
+      "label" : "2v.[02.wl.0000]",
+      "width" : 1974,
+      "height" : 2719,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0021",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0021",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0021_fa_0002v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1974,
+          "height" : 2719
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0021"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0021_fa_0002v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0022",
+      "@type" : "sc:Canvas",
+      "label" : "3r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0022",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0022",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0022_fa_0003r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0022"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0022_fa_0003r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0023",
+      "@type" : "sc:Canvas",
+      "label" : "3r.[02.wl.0000]",
+      "width" : 1995,
+      "height" : 2733,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0023",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0023",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0023_fa_0003r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1995,
+          "height" : 2733
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0023"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0023_fa_0003r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0024",
+      "@type" : "sc:Canvas",
+      "label" : "3v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0024",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0024",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0024_fa_0003v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0024"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0024_fa_0003v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0025",
+      "@type" : "sc:Canvas",
+      "label" : "3v.[02.wl.0000]",
+      "width" : 1985,
+      "height" : 2714,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0025",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0025",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0025_fa_0003v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1985,
+          "height" : 2714
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0025"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0025_fa_0003v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0026",
+      "@type" : "sc:Canvas",
+      "label" : "4r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0026",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0026",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0026_fa_0004r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0026"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0026_fa_0004r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0027",
+      "@type" : "sc:Canvas",
+      "label" : "4r.[02.wl.0000]",
+      "width" : 1973,
+      "height" : 2695,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0027",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0027",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0027_fa_0004r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1973,
+          "height" : 2695
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0027"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0027_fa_0004r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0028",
+      "@type" : "sc:Canvas",
+      "label" : "4v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0028",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0028",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0028_fa_0004v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0028"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0028_fa_0004v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0029",
+      "@type" : "sc:Canvas",
+      "label" : "4v.[02.wl.0000]",
+      "width" : 1926,
+      "height" : 2702,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0029",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0029",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0029_fa_0004v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1926,
+          "height" : 2702
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0029"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0029_fa_0004v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0030",
+      "@type" : "sc:Canvas",
+      "label" : "5r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0030",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0030",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0030_fa_0005r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0030"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0030_fa_0005r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0031",
+      "@type" : "sc:Canvas",
+      "label" : "5r.[02.wl.0000]",
+      "width" : 1942,
+      "height" : 2671,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0031",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0031",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0031_fa_0005r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1942,
+          "height" : 2671
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0031"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0031_fa_0005r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0032",
+      "@type" : "sc:Canvas",
+      "label" : "5v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0032",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0032",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0032_fa_0005v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0032"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0032_fa_0005v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0033",
+      "@type" : "sc:Canvas",
+      "label" : "5v.[02.wl.0000]",
+      "width" : 1972,
+      "height" : 2709,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0033",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0033",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0033_fa_0005v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1972,
+          "height" : 2709
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0033"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0033_fa_0005v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0034",
+      "@type" : "sc:Canvas",
+      "label" : "6r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0034",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0034",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0034_fa_0006r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0034"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0034_fa_0006r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0035",
+      "@type" : "sc:Canvas",
+      "label" : "6r.[02.wl.0000]",
+      "width" : 1973,
+      "height" : 2709,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0035",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0035",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0035_fa_0006r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1973,
+          "height" : 2709
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0035"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0035_fa_0006r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0036",
+      "@type" : "sc:Canvas",
+      "label" : "6v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0036",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0036",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0036_fa_0006v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0036"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0036_fa_0006v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0037",
+      "@type" : "sc:Canvas",
+      "label" : "6v.[02.wl.0000]",
+      "width" : 1944,
+      "height" : 2722,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0037",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0037",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0037_fa_0006v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1944,
+          "height" : 2722
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0037"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0037_fa_0006v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0038",
+      "@type" : "sc:Canvas",
+      "label" : "7r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0038",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0038",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0038_fa_0007r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0038"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0038_fa_0007r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0039",
+      "@type" : "sc:Canvas",
+      "label" : "7r.[02.wl.0000]",
+      "width" : 1953,
+      "height" : 2710,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0039",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0039",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0039_fa_0007r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1953,
+          "height" : 2710
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0039"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0039_fa_0007r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0040",
+      "@type" : "sc:Canvas",
+      "label" : "7v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0040",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0040",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0040_fa_0007v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0040"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0040_fa_0007v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0041",
+      "@type" : "sc:Canvas",
+      "label" : "7v.[02.wl.0000]",
+      "width" : 1935,
+      "height" : 2690,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0041",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0041",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0041_fa_0007v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1935,
+          "height" : 2690
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0041"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0041_fa_0007v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0042",
+      "@type" : "sc:Canvas",
+      "label" : "8r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0042",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0042",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0042_fa_0008r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0042"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0042_fa_0008r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0043",
+      "@type" : "sc:Canvas",
+      "label" : "8r.[02.wl.0000]",
+      "width" : 1958,
+      "height" : 2713,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0043",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0043",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0043_fa_0008r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1958,
+          "height" : 2713
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0043"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0043_fa_0008r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0044",
+      "@type" : "sc:Canvas",
+      "label" : "8v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0044",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0044",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0044_fa_0008v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0044"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0044_fa_0008v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0045",
+      "@type" : "sc:Canvas",
+      "label" : "8v.[02.wl.0000]",
+      "width" : 1986,
+      "height" : 2689,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0045",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0045",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0045_fa_0008v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1986,
+          "height" : 2689
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0045"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0045_fa_0008v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 110,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0046",
+      "@type" : "sc:Canvas",
+      "label" : "9r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0046",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0046",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0046_fa_0009r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0046"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0046_fa_0009r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0047",
+      "@type" : "sc:Canvas",
+      "label" : "9r.[02.wl.0000]",
+      "width" : 1968,
+      "height" : 2716,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0047",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0047",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0047_fa_0009r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1968,
+          "height" : 2716
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0047"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0047_fa_0009r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0048",
+      "@type" : "sc:Canvas",
+      "label" : "9v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0048",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0048",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0048_fa_0009v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0048"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0048_fa_0009v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0049",
+      "@type" : "sc:Canvas",
+      "label" : "9v.[02.wl.0000]",
+      "width" : 1943,
+      "height" : 2680,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0049",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0049",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0049_fa_0009v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1943,
+          "height" : 2680
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0049"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0049_fa_0009v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0050",
+      "@type" : "sc:Canvas",
+      "label" : "10r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0050",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0050",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0050_fa_0010r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0050"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0050_fa_0010r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0051",
+      "@type" : "sc:Canvas",
+      "label" : "10r.[02.wl.0000]",
+      "width" : 1961,
+      "height" : 2705,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0051",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0051",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0051_fa_0010r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1961,
+          "height" : 2705
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0051"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0051_fa_0010r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0052",
+      "@type" : "sc:Canvas",
+      "label" : "10v",
+      "width" : 1904,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0052",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0052",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0052_fa_0010v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1904,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0052"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0052_fa_0010v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0053",
+      "@type" : "sc:Canvas",
+      "label" : "10v.[02.wl.0000]",
+      "width" : 1951,
+      "height" : 2699,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0053",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0053",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0053_fa_0010v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1951,
+          "height" : 2699
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0053"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0053_fa_0010v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0054",
+      "@type" : "sc:Canvas",
+      "label" : "11r",
+      "width" : 1903,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0054",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0054",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0054_fa_0011r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1903,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0054"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0054_fa_0011r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 113,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0055",
+      "@type" : "sc:Canvas",
+      "label" : "11r.[02.wl.0000]",
+      "width" : 1965,
+      "height" : 2718,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0055",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0055",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0055_fa_0011r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1965,
+          "height" : 2718
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0055"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0055_fa_0011r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0056",
+      "@type" : "sc:Canvas",
+      "label" : "11v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0056",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0056",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0056_fa_0011v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0056"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0056_fa_0011v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0057",
+      "@type" : "sc:Canvas",
+      "label" : "11v.[02.wl.0000]",
+      "width" : 1957,
+      "height" : 2696,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0057",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0057",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0057_fa_0011v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1957,
+          "height" : 2696
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0057"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0057_fa_0011v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0058",
+      "@type" : "sc:Canvas",
+      "label" : "12r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0058",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0058",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0058_fa_0012r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0058"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0058_fa_0012r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0059",
+      "@type" : "sc:Canvas",
+      "label" : "12r.[02.wl.0000]",
+      "width" : 1953,
+      "height" : 2684,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0059",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0059",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0059_fa_0012r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1953,
+          "height" : 2684
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0059"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0059_fa_0012r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0060",
+      "@type" : "sc:Canvas",
+      "label" : "12v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0060",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0060",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0060_fa_0012v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0060"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0060_fa_0012v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0061",
+      "@type" : "sc:Canvas",
+      "label" : "12v.[02.wl.0000]",
+      "width" : 1936,
+      "height" : 2701,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0061",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0061",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0061_fa_0012v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1936,
+          "height" : 2701
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0061"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0061_fa_0012v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0062",
+      "@type" : "sc:Canvas",
+      "label" : "13r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0062",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0062",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0062_fa_0013r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0062"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0062_fa_0013r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0063",
+      "@type" : "sc:Canvas",
+      "label" : "13r.[02.wl.0000]",
+      "width" : 1943,
+      "height" : 2704,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0063",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0063",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0063_fa_0013r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1943,
+          "height" : 2704
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0063"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0063_fa_0013r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0064",
+      "@type" : "sc:Canvas",
+      "label" : "13v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0064",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0064",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0064_fa_0013v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0064"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0064_fa_0013v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0065",
+      "@type" : "sc:Canvas",
+      "label" : "13v.[02.wl.0000]",
+      "width" : 1935,
+      "height" : 2697,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0065",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0065",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0065_fa_0013v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1935,
+          "height" : 2697
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0065"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0065_fa_0013v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0066",
+      "@type" : "sc:Canvas",
+      "label" : "14r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0066",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0066",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0066_fa_0014r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0066"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0066_fa_0014r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0067",
+      "@type" : "sc:Canvas",
+      "label" : "14r.[02.wl.0000]",
+      "width" : 1931,
+      "height" : 2703,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0067",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0067",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0067_fa_0014r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1931,
+          "height" : 2703
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0067"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0067_fa_0014r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0068",
+      "@type" : "sc:Canvas",
+      "label" : "14v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0068",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0068",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0068_fa_0014v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0068"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0068_fa_0014v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0069",
+      "@type" : "sc:Canvas",
+      "label" : "14v.[02.wl.0000]",
+      "width" : 1935,
+      "height" : 2699,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0069",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0069",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0069_fa_0014v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1935,
+          "height" : 2699
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0069"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0069_fa_0014v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0070",
+      "@type" : "sc:Canvas",
+      "label" : "15r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0070",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0070",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0070_fa_0015r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0070"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0070_fa_0015r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0071",
+      "@type" : "sc:Canvas",
+      "label" : "15r.[02.wl.0000]",
+      "width" : 1921,
+      "height" : 2696,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0071",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0071",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0071_fa_0015r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1921,
+          "height" : 2696
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0071"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0071_fa_0015r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0072",
+      "@type" : "sc:Canvas",
+      "label" : "15v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0072",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0072",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0072_fa_0015v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0072"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0072_fa_0015v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0073",
+      "@type" : "sc:Canvas",
+      "label" : "15v.[02.wl.0000]",
+      "width" : 1911,
+      "height" : 2681,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0073",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0073",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0073_fa_0015v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1911,
+          "height" : 2681
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0073"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0073_fa_0015v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0074",
+      "@type" : "sc:Canvas",
+      "label" : "16r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0074",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0074",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0074_fa_0016r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0074"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0074_fa_0016r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0075",
+      "@type" : "sc:Canvas",
+      "label" : "16r.[02.wl.0000]",
+      "width" : 1979,
+      "height" : 2704,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0075",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0075",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0075_fa_0016r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1979,
+          "height" : 2704
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0075"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0075_fa_0016r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0076",
+      "@type" : "sc:Canvas",
+      "label" : "16v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0076",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0076",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0076_fa_0016v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0076"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0076_fa_0016v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0077",
+      "@type" : "sc:Canvas",
+      "label" : "16v.[02.wl.0000]",
+      "width" : 1975,
+      "height" : 2667,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0077",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0077",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0077_fa_0016v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1975,
+          "height" : 2667
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0077"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0077_fa_0016v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 111,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0078",
+      "@type" : "sc:Canvas",
+      "label" : "17r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0078",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0078",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0078_fa_0017r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0078"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0078_fa_0017r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0079",
+      "@type" : "sc:Canvas",
+      "label" : "17r.[02.wl.0000]",
+      "width" : 1979,
+      "height" : 2698,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0079",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0079",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0079_fa_0017r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1979,
+          "height" : 2698
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0079"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0079_fa_0017r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 110,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0080",
+      "@type" : "sc:Canvas",
+      "label" : "17v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0080",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0080",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0080_fa_0017v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0080"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0080_fa_0017v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0081",
+      "@type" : "sc:Canvas",
+      "label" : "17v.[02.wl.0000]",
+      "width" : 1947,
+      "height" : 2697,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0081",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0081",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0081_fa_0017v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1947,
+          "height" : 2697
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0081"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0081_fa_0017v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0082",
+      "@type" : "sc:Canvas",
+      "label" : "18r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0082",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0082",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0082_fa_0018r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0082"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0082_fa_0018r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0083",
+      "@type" : "sc:Canvas",
+      "label" : "18r.[02.wl.0000]",
+      "width" : 1922,
+      "height" : 2689,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0083",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0083",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0083_fa_0018r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1922,
+          "height" : 2689
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0083"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0083_fa_0018r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0084",
+      "@type" : "sc:Canvas",
+      "label" : "18v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0084",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0084",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0084_fa_0018v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0084"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0084_fa_0018v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0085",
+      "@type" : "sc:Canvas",
+      "label" : "18v.[02.wl.0000]",
+      "width" : 1961,
+      "height" : 2676,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0085",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0085",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0085_fa_0018v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1961,
+          "height" : 2676
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0085"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0085_fa_0018v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0086",
+      "@type" : "sc:Canvas",
+      "label" : "19r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0086",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0086",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0086_fa_0019r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0086"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0086_fa_0019r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0087",
+      "@type" : "sc:Canvas",
+      "label" : "19r.[02.wl.0000]",
+      "width" : 1949,
+      "height" : 2701,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0087",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0087",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0087_fa_0019r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1949,
+          "height" : 2701
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0087"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0087_fa_0019r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0088",
+      "@type" : "sc:Canvas",
+      "label" : "19v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0088",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0088",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0088_fa_0019v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0088"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0088_fa_0019v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0089",
+      "@type" : "sc:Canvas",
+      "label" : "19v.[02.wl.0000]",
+      "width" : 1947,
+      "height" : 2702,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0089",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0089",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0089_fa_0019v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1947,
+          "height" : 2702
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0089"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0089_fa_0019v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0090",
+      "@type" : "sc:Canvas",
+      "label" : "20r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0090",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0090",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0090_fa_0020r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0090"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0090_fa_0020r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0091",
+      "@type" : "sc:Canvas",
+      "label" : "20r.[02.wl.0000]",
+      "width" : 1947,
+      "height" : 2676,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0091",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0091",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0091_fa_0020r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1947,
+          "height" : 2676
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0091"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0091_fa_0020r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0092",
+      "@type" : "sc:Canvas",
+      "label" : "20v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0092",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0092",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0092_fa_0020v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0092"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0092_fa_0020v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0093",
+      "@type" : "sc:Canvas",
+      "label" : "20v.[02.wl.0000]",
+      "width" : 1947,
+      "height" : 2700,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0093",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0093",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0093_fa_0020v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1947,
+          "height" : 2700
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0093"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0093_fa_0020v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0094",
+      "@type" : "sc:Canvas",
+      "label" : "21r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0094",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0094",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0094_fa_0021r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0094"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0094_fa_0021r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0095",
+      "@type" : "sc:Canvas",
+      "label" : "21r.[02.wl.0000]",
+      "width" : 2580,
+      "height" : 3579,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0095",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0095",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0095_fa_0021r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2580,
+          "height" : 3579
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0095"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0095_fa_0021r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0096",
+      "@type" : "sc:Canvas",
+      "label" : "21v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0096",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0096",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0096_fa_0021v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0096"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0096_fa_0021v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0097",
+      "@type" : "sc:Canvas",
+      "label" : "21v.[02.wl.0000]",
+      "width" : 1961,
+      "height" : 2674,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0097",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0097",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0097_fa_0021v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1961,
+          "height" : 2674
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0097"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0097_fa_0021v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 110,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0098",
+      "@type" : "sc:Canvas",
+      "label" : "22r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0098",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0098",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0098_fa_0022r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0098"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0098_fa_0022r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0099",
+      "@type" : "sc:Canvas",
+      "label" : "22r.[02.wl.0000]",
+      "width" : 1949,
+      "height" : 2685,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0099",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0099",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0099_fa_0022r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1949,
+          "height" : 2685
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0099"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0099_fa_0022r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0100",
+      "@type" : "sc:Canvas",
+      "label" : "22v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0100",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0100",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0100_fa_0022v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0100"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0100_fa_0022v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0101",
+      "@type" : "sc:Canvas",
+      "label" : "22v.[02.wl.0000]",
+      "width" : 1951,
+      "height" : 2676,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0101",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0101",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0101_fa_0022v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1951,
+          "height" : 2676
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0101"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0101_fa_0022v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0102",
+      "@type" : "sc:Canvas",
+      "label" : "23r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0102",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0102",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0102_fa_0023r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0102"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0102_fa_0023r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0103",
+      "@type" : "sc:Canvas",
+      "label" : "23r.[02.wl.0000]",
+      "width" : 1979,
+      "height" : 2714,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0103",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0103",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0103_fa_0023r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1979,
+          "height" : 2714
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0103"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0103_fa_0023r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0104",
+      "@type" : "sc:Canvas",
+      "label" : "23v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0104",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0104",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0104_fa_0023v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0104"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0104_fa_0023v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0105",
+      "@type" : "sc:Canvas",
+      "label" : "23v.[02.wl.0000]",
+      "width" : 1966,
+      "height" : 2679,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0105",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0105",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0105_fa_0023v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1966,
+          "height" : 2679
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0105"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0105_fa_0023v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 110,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0106",
+      "@type" : "sc:Canvas",
+      "label" : "24r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0106",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0106",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0106_fa_0024r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0106"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0106_fa_0024r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0107",
+      "@type" : "sc:Canvas",
+      "label" : "24r.[02.wl.0000]",
+      "width" : 1958,
+      "height" : 2714,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0107",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0107",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0107_fa_0024r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1958,
+          "height" : 2714
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0107"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0107_fa_0024r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0108",
+      "@type" : "sc:Canvas",
+      "label" : "24v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0108",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0108",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0108_fa_0024v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0108"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0108_fa_0024v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0109",
+      "@type" : "sc:Canvas",
+      "label" : "24v.[02.wl.0000]",
+      "width" : 1966,
+      "height" : 2691,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0109",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0109",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0109_fa_0024v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1966,
+          "height" : 2691
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0109"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0109_fa_0024v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0110",
+      "@type" : "sc:Canvas",
+      "label" : "25r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0110",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0110",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0110_fa_0025r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0110"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0110_fa_0025r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0111",
+      "@type" : "sc:Canvas",
+      "label" : "25r.[02.wl.0000]",
+      "width" : 1994,
+      "height" : 2705,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0111",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0111",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0111_fa_0025r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1994,
+          "height" : 2705
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0111"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0111_fa_0025r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 110,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0112",
+      "@type" : "sc:Canvas",
+      "label" : "25v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0112",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0112",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0112_fa_0025v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0112"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0112_fa_0025v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0113",
+      "@type" : "sc:Canvas",
+      "label" : "25v.[02.wl.0000]",
+      "width" : 1912,
+      "height" : 2668,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0113",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0113",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0113_fa_0025v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1912,
+          "height" : 2668
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0113"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0113_fa_0025v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0114",
+      "@type" : "sc:Canvas",
+      "label" : "26r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0114",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0114",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0114_fa_0026r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0114"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0114_fa_0026r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0115",
+      "@type" : "sc:Canvas",
+      "label" : "26r.[02.wl.0000]",
+      "width" : 1954,
+      "height" : 2683,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0115",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0115",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0115_fa_0026r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1954,
+          "height" : 2683
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0115"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0115_fa_0026r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0116",
+      "@type" : "sc:Canvas",
+      "label" : "26v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0116",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0116",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0116_fa_0026v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0116"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0116_fa_0026v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0117",
+      "@type" : "sc:Canvas",
+      "label" : "26v.[02.wl.0000]",
+      "width" : 1951,
+      "height" : 2671,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0117",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0117",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0117_fa_0026v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1951,
+          "height" : 2671
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0117"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0117_fa_0026v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0118",
+      "@type" : "sc:Canvas",
+      "label" : "27r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0118",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0118",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0118_fa_0027r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0118"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0118_fa_0027r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0119",
+      "@type" : "sc:Canvas",
+      "label" : "27r.[02.wl.0000]",
+      "width" : 2519,
+      "height" : 3544,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0119",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0119",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0119_fa_0027r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2519,
+          "height" : 3544
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0119"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0119_fa_0027r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0120",
+      "@type" : "sc:Canvas",
+      "label" : "27v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0120",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0120",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0120_fa_0027v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0120"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0120_fa_0027v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0121",
+      "@type" : "sc:Canvas",
+      "label" : "27v.[02.wl.0000]",
+      "width" : 1918,
+      "height" : 2688,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0121",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0121",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0121_fa_0027v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1918,
+          "height" : 2688
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0121"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0121_fa_0027v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0122",
+      "@type" : "sc:Canvas",
+      "label" : "28r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0122",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0122",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0122_fa_0028r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0122"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0122_fa_0028r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0123",
+      "@type" : "sc:Canvas",
+      "label" : "28r.[02.wl.0000]",
+      "width" : 1938,
+      "height" : 2678,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0123",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0123",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0123_fa_0028r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1938,
+          "height" : 2678
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0123"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0123_fa_0028r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0124",
+      "@type" : "sc:Canvas",
+      "label" : "28v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0124",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0124",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0124_fa_0028v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0124"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0124_fa_0028v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0125",
+      "@type" : "sc:Canvas",
+      "label" : "28v.[02.wl.0000]",
+      "width" : 1970,
+      "height" : 2691,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0125",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0125",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0125_fa_0028v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1970,
+          "height" : 2691
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0125"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0125_fa_0028v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0126",
+      "@type" : "sc:Canvas",
+      "label" : "29r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0126",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0126",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0126_fa_0029r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0126"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0126_fa_0029r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0127",
+      "@type" : "sc:Canvas",
+      "label" : "29r.[02.wl.0000]",
+      "width" : 1918,
+      "height" : 2675,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0127",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0127",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0127_fa_0029r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1918,
+          "height" : 2675
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0127"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0127_fa_0029r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0128",
+      "@type" : "sc:Canvas",
+      "label" : "29v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0128",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0128",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0128_fa_0029v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0128"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0128_fa_0029v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0129",
+      "@type" : "sc:Canvas",
+      "label" : "29v.[02.wl.0000]",
+      "width" : 1976,
+      "height" : 2713,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0129",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0129",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0129_fa_0029v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1976,
+          "height" : 2713
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0129"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0129_fa_0029v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0130",
+      "@type" : "sc:Canvas",
+      "label" : "30r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0130",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0130",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0130_fa_0030r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0130"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0130_fa_0030r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0131",
+      "@type" : "sc:Canvas",
+      "label" : "30r.[02.wl.0000]",
+      "width" : 2630,
+      "height" : 3578,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0131",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0131",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0131_fa_0030r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2630,
+          "height" : 3578
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0131"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0131_fa_0030r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 110,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0132",
+      "@type" : "sc:Canvas",
+      "label" : "30v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0132",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0132",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0132_fa_0030v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0132"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0132_fa_0030v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0133",
+      "@type" : "sc:Canvas",
+      "label" : "30v.[02.wl.0000]",
+      "width" : 1999,
+      "height" : 2710,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0133",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0133",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0133_fa_0030v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1999,
+          "height" : 2710
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0133"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0133_fa_0030v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 110,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0134",
+      "@type" : "sc:Canvas",
+      "label" : "31r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0134",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0134",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0134_fa_0031r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0134"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0134_fa_0031r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0135",
+      "@type" : "sc:Canvas",
+      "label" : "31r.[02.wl.0000]",
+      "width" : 1967,
+      "height" : 2714,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0135",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0135",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0135_fa_0031r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1967,
+          "height" : 2714
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0135"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0135_fa_0031r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0136",
+      "@type" : "sc:Canvas",
+      "label" : "31v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0136",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0136",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0136_fa_0031v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0136"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0136_fa_0031v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0137",
+      "@type" : "sc:Canvas",
+      "label" : "31v.[02.wl.0000]",
+      "width" : 1947,
+      "height" : 2708,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0137",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0137",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0137_fa_0031v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1947,
+          "height" : 2708
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0137"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0137_fa_0031v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0138",
+      "@type" : "sc:Canvas",
+      "label" : "32r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0138",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0138",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0138_fa_0032r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0138"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0138_fa_0032r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0139",
+      "@type" : "sc:Canvas",
+      "label" : "32r.[02.wl.0000]",
+      "width" : 2528,
+      "height" : 3571,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0139",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0139",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0139_fa_0032r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2528,
+          "height" : 3571
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0139"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0139_fa_0032r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0140",
+      "@type" : "sc:Canvas",
+      "label" : "32v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0140",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0140",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0140_fa_0032v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0140"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0140_fa_0032v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0141",
+      "@type" : "sc:Canvas",
+      "label" : "32v.[02.wl.0000]",
+      "width" : 1951,
+      "height" : 2703,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0141",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0141",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0141_fa_0032v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1951,
+          "height" : 2703
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0141"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0141_fa_0032v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0142",
+      "@type" : "sc:Canvas",
+      "label" : "33r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0142",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0142",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0142_fa_0033r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0142"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0142_fa_0033r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0143",
+      "@type" : "sc:Canvas",
+      "label" : "33r.[02.wl.0000]",
+      "width" : 2552,
+      "height" : 3605,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0143",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0143",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0143_fa_0033r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2552,
+          "height" : 3605
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0143"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0143_fa_0033r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0144",
+      "@type" : "sc:Canvas",
+      "label" : "33v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0144",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0144",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0144_fa_0033v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0144"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0144_fa_0033v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0145",
+      "@type" : "sc:Canvas",
+      "label" : "33v.[02.wl.0000]",
+      "width" : 1969,
+      "height" : 2722,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0145",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0145",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0145_fa_0033v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1969,
+          "height" : 2722
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0145"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0145_fa_0033v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0146",
+      "@type" : "sc:Canvas",
+      "label" : "34r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0146",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0146",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0146_fa_0034r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0146"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0146_fa_0034r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0147",
+      "@type" : "sc:Canvas",
+      "label" : "34r.[02.wl.0000]",
+      "width" : 1989,
+      "height" : 2735,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0147",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0147",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0147_fa_0034r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1989,
+          "height" : 2735
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0147"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0147_fa_0034r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0148",
+      "@type" : "sc:Canvas",
+      "label" : "34v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0148",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0148",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0148_fa_0034v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0148"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0148_fa_0034v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0149",
+      "@type" : "sc:Canvas",
+      "label" : "34v.[02.wl.0000]",
+      "width" : 1949,
+      "height" : 2756,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0149",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0149",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0149_fa_0034v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1949,
+          "height" : 2756
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0149"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0149_fa_0034v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0150",
+      "@type" : "sc:Canvas",
+      "label" : "35r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0150",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0150",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0150_fa_0035r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0150"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0150_fa_0035r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0151",
+      "@type" : "sc:Canvas",
+      "label" : "35r.[02.wl.0000]",
+      "width" : 1978,
+      "height" : 2758,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0151",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0151",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0151_fa_0035r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1978,
+          "height" : 2758
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0151"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0151_fa_0035r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0152",
+      "@type" : "sc:Canvas",
+      "label" : "35v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0152",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0152",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0152_fa_0035v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0152"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0152_fa_0035v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0153",
+      "@type" : "sc:Canvas",
+      "label" : "35v.[02.wl.0000]",
+      "width" : 1949,
+      "height" : 2742,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0153",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0153",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0153_fa_0035v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1949,
+          "height" : 2742
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0153"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0153_fa_0035v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0154",
+      "@type" : "sc:Canvas",
+      "label" : "36r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0154",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0154",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0154_fa_0036r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0154"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0154_fa_0036r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0155",
+      "@type" : "sc:Canvas",
+      "label" : "36r.[02.wl.0000]",
+      "width" : 1965,
+      "height" : 2728,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0155",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0155",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0155_fa_0036r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1965,
+          "height" : 2728
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0155"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0155_fa_0036r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0156",
+      "@type" : "sc:Canvas",
+      "label" : "36v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0156",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0156",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0156_fa_0036v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0156"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0156_fa_0036v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0157",
+      "@type" : "sc:Canvas",
+      "label" : "36v.[02.wl.0000]",
+      "width" : 1955,
+      "height" : 2715,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0157",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0157",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0157_fa_0036v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1955,
+          "height" : 2715
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0157"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0157_fa_0036v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0158",
+      "@type" : "sc:Canvas",
+      "label" : "37r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0158",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0158",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0158_fa_0037r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0158"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0158_fa_0037r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0159",
+      "@type" : "sc:Canvas",
+      "label" : "37r.[02.wl.0000]",
+      "width" : 1938,
+      "height" : 2718,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0159",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0159",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0159_fa_0037r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1938,
+          "height" : 2718
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0159"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0159_fa_0037r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0160",
+      "@type" : "sc:Canvas",
+      "label" : "37v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0160",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0160",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0160_fa_0037v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0160"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0160_fa_0037v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0161",
+      "@type" : "sc:Canvas",
+      "label" : "37v.[02.wl.0000]",
+      "width" : 2565,
+      "height" : 3566,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0161",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0161",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0161_fa_0037v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2565,
+          "height" : 3566
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0161"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0161_fa_0037v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0162",
+      "@type" : "sc:Canvas",
+      "label" : "38r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0162",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0162",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0162_fa_0038r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0162"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0162_fa_0038r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0163",
+      "@type" : "sc:Canvas",
+      "label" : "38r.[02.wl.0000]",
+      "width" : 1951,
+      "height" : 2730,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0163",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0163",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0163_fa_0038r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1951,
+          "height" : 2730
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0163"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0163_fa_0038r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0164",
+      "@type" : "sc:Canvas",
+      "label" : "38v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0164",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0164",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0164_fa_0038v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0164"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0164_fa_0038v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0165",
+      "@type" : "sc:Canvas",
+      "label" : "38v.[02.wl.0000]",
+      "width" : 1963,
+      "height" : 2724,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0165",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0165",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0165_fa_0038v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1963,
+          "height" : 2724
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0165"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0165_fa_0038v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0166",
+      "@type" : "sc:Canvas",
+      "label" : "39r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0166",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0166",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0166_fa_0039r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0166"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0166_fa_0039r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0167",
+      "@type" : "sc:Canvas",
+      "label" : "39r.[02.wl.0000]",
+      "width" : 1971,
+      "height" : 2731,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0167",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0167",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0167_fa_0039r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1971,
+          "height" : 2731
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0167"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0167_fa_0039r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0168",
+      "@type" : "sc:Canvas",
+      "label" : "39v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0168",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0168",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0168_fa_0039v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0168"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0168_fa_0039v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0169",
+      "@type" : "sc:Canvas",
+      "label" : "39v.[02.wl.0000]",
+      "width" : 1948,
+      "height" : 2746,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0169",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0169",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0169_fa_0039v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1948,
+          "height" : 2746
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0169"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0169_fa_0039v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0170",
+      "@type" : "sc:Canvas",
+      "label" : "40r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0170",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0170",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0170_fa_0040r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0170"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0170_fa_0040r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0171",
+      "@type" : "sc:Canvas",
+      "label" : "40r.[02.hn.0000]",
+      "width" : 1972,
+      "height" : 2700,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0171",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0171",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0171_fa_0040r.%5B02.hn.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1972,
+          "height" : 2700
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0171"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0171_fa_0040r.%5B02.hn.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0172",
+      "@type" : "sc:Canvas",
+      "label" : "40v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0172",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0172",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0172_fa_0040v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0172"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0172_fa_0040v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0173",
+      "@type" : "sc:Canvas",
+      "label" : "40v.[02.wl.0000]",
+      "width" : 1983,
+      "height" : 2720,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0173",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0173",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0173_fa_0040v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1983,
+          "height" : 2720
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0173"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0173_fa_0040v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0174",
+      "@type" : "sc:Canvas",
+      "label" : "41r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0174",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0174",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0174_fa_0041r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0174"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0174_fa_0041r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0175",
+      "@type" : "sc:Canvas",
+      "label" : "41r.[02.wl.0000]",
+      "width" : 1985,
+      "height" : 2714,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0175",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0175",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0175_fa_0041r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1985,
+          "height" : 2714
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0175"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0175_fa_0041r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0176",
+      "@type" : "sc:Canvas",
+      "label" : "41v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0176",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0176",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0176_fa_0041v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0176"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0176_fa_0041v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0177",
+      "@type" : "sc:Canvas",
+      "label" : "41v.[02.wl.0000]",
+      "width" : 1981,
+      "height" : 2732,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0177",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0177",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0177_fa_0041v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1981,
+          "height" : 2732
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0177"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0177_fa_0041v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0178",
+      "@type" : "sc:Canvas",
+      "label" : "42r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0178",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0178",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0178_fa_0042r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0178"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0178_fa_0042r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0179",
+      "@type" : "sc:Canvas",
+      "label" : "42r.[02.wl.0000]",
+      "width" : 1989,
+      "height" : 2716,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0179",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0179",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0179_fa_0042r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1989,
+          "height" : 2716
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0179"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0179_fa_0042r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0180",
+      "@type" : "sc:Canvas",
+      "label" : "42v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0180",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0180",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0180_fa_0042v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0180"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0180_fa_0042v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0181",
+      "@type" : "sc:Canvas",
+      "label" : "42v.[02.wl.0000]",
+      "width" : 1965,
+      "height" : 2715,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0181",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0181",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0181_fa_0042v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1965,
+          "height" : 2715
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0181"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0181_fa_0042v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0182",
+      "@type" : "sc:Canvas",
+      "label" : "43r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0182",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0182",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0182_fa_0043r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0182"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0182_fa_0043r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0183",
+      "@type" : "sc:Canvas",
+      "label" : "43r.[02.wl.0000]",
+      "width" : 1981,
+      "height" : 2740,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0183",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0183",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0183_fa_0043r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1981,
+          "height" : 2740
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0183"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0183_fa_0043r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0184",
+      "@type" : "sc:Canvas",
+      "label" : "43v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0184",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0184",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0184_fa_0043v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0184"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0184_fa_0043v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0185",
+      "@type" : "sc:Canvas",
+      "label" : "43v.[02.wl.0000]",
+      "width" : 1978,
+      "height" : 2745,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0185",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0185",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0185_fa_0043v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1978,
+          "height" : 2745
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0185"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0185_fa_0043v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0186",
+      "@type" : "sc:Canvas",
+      "label" : "44r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0186",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0186",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0186_fa_0044r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0186"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0186_fa_0044r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0187",
+      "@type" : "sc:Canvas",
+      "label" : "44r.[02.wl.0000]",
+      "width" : 1981,
+      "height" : 2728,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0187",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0187",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0187_fa_0044r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1981,
+          "height" : 2728
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0187"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0187_fa_0044r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0188",
+      "@type" : "sc:Canvas",
+      "label" : "44v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0188",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0188",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0188_fa_0044v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0188"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0188_fa_0044v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0189",
+      "@type" : "sc:Canvas",
+      "label" : "44v.[02.wl.0000]",
+      "width" : 1968,
+      "height" : 2720,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0189",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0189",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0189_fa_0044v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1968,
+          "height" : 2720
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0189"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0189_fa_0044v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0190",
+      "@type" : "sc:Canvas",
+      "label" : "45r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0190",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0190",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0190_fa_0045r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0190"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0190_fa_0045r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0191",
+      "@type" : "sc:Canvas",
+      "label" : "45r.[02.wl.0000]",
+      "width" : 1955,
+      "height" : 2723,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0191",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0191",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0191_fa_0045r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1955,
+          "height" : 2723
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0191"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0191_fa_0045r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0192",
+      "@type" : "sc:Canvas",
+      "label" : "45v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0192",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0192",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0192_fa_0045v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0192"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0192_fa_0045v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0193",
+      "@type" : "sc:Canvas",
+      "label" : "45v.[02.wl.0000]",
+      "width" : 1991,
+      "height" : 2727,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0193",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0193",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0193_fa_0045v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1991,
+          "height" : 2727
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0193"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0193_fa_0045v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0194",
+      "@type" : "sc:Canvas",
+      "label" : "46r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0194",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0194",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0194_fa_0046r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0194"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0194_fa_0046r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0195",
+      "@type" : "sc:Canvas",
+      "label" : "46r.[02.wl.0000]",
+      "width" : 1985,
+      "height" : 2721,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0195",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0195",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0195_fa_0046r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1985,
+          "height" : 2721
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0195"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0195_fa_0046r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0196",
+      "@type" : "sc:Canvas",
+      "label" : "46v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0196",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0196",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0196_fa_0046v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0196"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0196_fa_0046v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0197",
+      "@type" : "sc:Canvas",
+      "label" : "46v.[02.wl.0000]",
+      "width" : 1962,
+      "height" : 2745,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0197",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0197",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0197_fa_0046v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1962,
+          "height" : 2745
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0197"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0197_fa_0046v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0198",
+      "@type" : "sc:Canvas",
+      "label" : "47r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0198",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0198",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0198_fa_0047r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0198"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0198_fa_0047r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0199",
+      "@type" : "sc:Canvas",
+      "label" : "47r.[02.wl.0000]",
+      "width" : 1983,
+      "height" : 2720,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0199",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0199",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0199_fa_0047r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1983,
+          "height" : 2720
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0199"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0199_fa_0047r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0200",
+      "@type" : "sc:Canvas",
+      "label" : "47v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0200",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0200",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0200_fa_0047v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0200"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0200_fa_0047v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0201",
+      "@type" : "sc:Canvas",
+      "label" : "47v.[02.wl.0000]",
+      "width" : 1970,
+      "height" : 2713,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0201",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0201",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0201_fa_0047v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1970,
+          "height" : 2713
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0201"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0201_fa_0047v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0202",
+      "@type" : "sc:Canvas",
+      "label" : "48r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0202",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0202",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0202_fa_0048r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0202"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0202_fa_0048r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0203",
+      "@type" : "sc:Canvas",
+      "label" : "48r.[02.wl.0000]",
+      "width" : 1998,
+      "height" : 2745,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0203",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0203",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0203_fa_0048r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1998,
+          "height" : 2745
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0203"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0203_fa_0048r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0204",
+      "@type" : "sc:Canvas",
+      "label" : "48v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0204",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0204",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0204_fa_0048v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0204"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0204_fa_0048v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0205",
+      "@type" : "sc:Canvas",
+      "label" : "48v.[02.wl.0000]",
+      "width" : 1989,
+      "height" : 2696,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0205",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0205",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0205_fa_0048v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1989,
+          "height" : 2696
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0205"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0205_fa_0048v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 110,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0206",
+      "@type" : "sc:Canvas",
+      "label" : "49r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0206",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0206",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0206_fa_0049r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0206"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0206_fa_0049r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0207",
+      "@type" : "sc:Canvas",
+      "label" : "49r.[02.wl.0000]",
+      "width" : 1980,
+      "height" : 2738,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0207",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0207",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0207_fa_0049r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1980,
+          "height" : 2738
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0207"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0207_fa_0049r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0208",
+      "@type" : "sc:Canvas",
+      "label" : "49v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0208",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0208",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0208_fa_0049v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0208"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0208_fa_0049v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0209",
+      "@type" : "sc:Canvas",
+      "label" : "49v.[02.wl.0000]",
+      "width" : 2003,
+      "height" : 2733,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0209",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0209",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0209_fa_0049v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2003,
+          "height" : 2733
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0209"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0209_fa_0049v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0210",
+      "@type" : "sc:Canvas",
+      "label" : "50r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0210",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0210",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0210_fa_0050r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0210"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0210_fa_0050r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0211",
+      "@type" : "sc:Canvas",
+      "label" : "50r.[02.wl.0000]",
+      "width" : 1967,
+      "height" : 2719,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0211",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0211",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0211_fa_0050r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1967,
+          "height" : 2719
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0211"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0211_fa_0050r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0212",
+      "@type" : "sc:Canvas",
+      "label" : "50v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0212",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0212",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0212_fa_0050v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0212"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0212_fa_0050v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0213",
+      "@type" : "sc:Canvas",
+      "label" : "51r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0213",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0213",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0213_fa_0051r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0213"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0213_fa_0051r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0214",
+      "@type" : "sc:Canvas",
+      "label" : "51v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0214",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0214",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0214_fa_0051v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0214"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0214_fa_0051v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0215",
+      "@type" : "sc:Canvas",
+      "label" : "52r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0215",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0215",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0215_fa_0052r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0215"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0215_fa_0052r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      }
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0216",
+      "@type" : "sc:Canvas",
+      "label" : "52v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0216",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0216",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0216_fa_0052v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0216"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0216_fa_0052v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0217",
+      "@type" : "sc:Canvas",
+      "label" : "52v.[02.wl.0000]",
+      "width" : 1973,
+      "height" : 2701,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0217",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0217",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0217_fa_0052v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1973,
+          "height" : 2701
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0217"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0217_fa_0052v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0218",
+      "@type" : "sc:Canvas",
+      "label" : "53r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0218",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0218",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0218_fa_0053r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0218"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0218_fa_0053r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0219",
+      "@type" : "sc:Canvas",
+      "label" : "53r.[02.wl.0000]",
+      "width" : 2007,
+      "height" : 2721,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0219",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0219",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0219_fa_0053r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 2007,
+          "height" : 2721
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0219"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0219_fa_0053r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 110,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0220",
+      "@type" : "sc:Canvas",
+      "label" : "53v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0220",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0220",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0220_fa_0053v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0220"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0220_fa_0053v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0221",
+      "@type" : "sc:Canvas",
+      "label" : "53v.[02.wl.0000]",
+      "width" : 1960,
+      "height" : 2742,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0221",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0221",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0221_fa_0053v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1960,
+          "height" : 2742
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0221"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0221_fa_0053v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0222",
+      "@type" : "sc:Canvas",
+      "label" : "54r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0222",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0222",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0222_fa_0054r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0222"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0222_fa_0054r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0223",
+      "@type" : "sc:Canvas",
+      "label" : "54r.[02.wl.0000]",
+      "width" : 1987,
+      "height" : 2720,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0223",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0223",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0223_fa_0054r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1987,
+          "height" : 2720
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0223"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0223_fa_0054r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0224",
+      "@type" : "sc:Canvas",
+      "label" : "54v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0224",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0224",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0224_fa_0054v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0224"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0224_fa_0054v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0225",
+      "@type" : "sc:Canvas",
+      "label" : "54v.[02.wl.0000]",
+      "width" : 1983,
+      "height" : 2720,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0225",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0225",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0225_fa_0054v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1983,
+          "height" : 2720
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0225"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0225_fa_0054v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0226",
+      "@type" : "sc:Canvas",
+      "label" : "55r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0226",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0226",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0226_fa_0055r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0226"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0226_fa_0055r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0227",
+      "@type" : "sc:Canvas",
+      "label" : "55r.[02.wl.0000]",
+      "width" : 1965,
+      "height" : 2749,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0227",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0227",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0227_fa_0055r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1965,
+          "height" : 2749
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0227"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0227_fa_0055r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0228",
+      "@type" : "sc:Canvas",
+      "label" : "55v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0228",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0228",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0228_fa_0055v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0228"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0228_fa_0055v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0229",
+      "@type" : "sc:Canvas",
+      "label" : "55v.[02.wl.0000]",
+      "width" : 1973,
+      "height" : 2737,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0229",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0229",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0229_fa_0055v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1973,
+          "height" : 2737
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0229"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0229_fa_0055v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0230",
+      "@type" : "sc:Canvas",
+      "label" : "56r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0230",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0230",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0230_fa_0056r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0230"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0230_fa_0056r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0231",
+      "@type" : "sc:Canvas",
+      "label" : "56r.[02.wl.0000]",
+      "width" : 1951,
+      "height" : 2730,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0231",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0231",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0231_fa_0056r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1951,
+          "height" : 2730
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0231"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0231_fa_0056r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0232",
+      "@type" : "sc:Canvas",
+      "label" : "56v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0232",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0232",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0232_fa_0056v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0232"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0232_fa_0056v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0233",
+      "@type" : "sc:Canvas",
+      "label" : "56v.[02.wl.0000]",
+      "width" : 1974,
+      "height" : 2741,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0233",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0233",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0233_fa_0056v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1974,
+          "height" : 2741
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0233"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0233_fa_0056v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0234",
+      "@type" : "sc:Canvas",
+      "label" : "57r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0234",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0234",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0234_fa_0057r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0234"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0234_fa_0057r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0235",
+      "@type" : "sc:Canvas",
+      "label" : "57r.[02.wl.0000]",
+      "width" : 1940,
+      "height" : 2715,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0235",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0235",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0235_fa_0057r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2715
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0235"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0235_fa_0057r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0236",
+      "@type" : "sc:Canvas",
+      "label" : "57v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0236",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0236",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0236_fa_0057v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0236"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0236_fa_0057v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0237",
+      "@type" : "sc:Canvas",
+      "label" : "57v.[02.wl.0000]",
+      "width" : 1985,
+      "height" : 2720,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0237",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0237",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0237_fa_0057v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1985,
+          "height" : 2720
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0237"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0237_fa_0057v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0238",
+      "@type" : "sc:Canvas",
+      "label" : "58r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0238",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0238",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0238_fa_0058r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0238"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0238_fa_0058r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0239",
+      "@type" : "sc:Canvas",
+      "label" : "58r.[02.wl.0000]",
+      "width" : 1967,
+      "height" : 2719,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0239",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0239",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0239_fa_0058r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1967,
+          "height" : 2719
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0239"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0239_fa_0058r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0240",
+      "@type" : "sc:Canvas",
+      "label" : "58v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0240",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0240",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0240_fa_0058v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0240"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0240_fa_0058v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0241",
+      "@type" : "sc:Canvas",
+      "label" : "58v.[02.wl.0000]",
+      "width" : 1963,
+      "height" : 2718,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0241",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0241",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0241_fa_0058v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1963,
+          "height" : 2718
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0241"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0241_fa_0058v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0242",
+      "@type" : "sc:Canvas",
+      "label" : "59r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0242",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0242",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0242_fa_0059r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0242"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0242_fa_0059r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0243",
+      "@type" : "sc:Canvas",
+      "label" : "59r.[02.wl.0000]",
+      "width" : 1939,
+      "height" : 2705,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0243",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0243",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0243_fa_0059r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1939,
+          "height" : 2705
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0243"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0243_fa_0059r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0244",
+      "@type" : "sc:Canvas",
+      "label" : "59v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0244",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0244",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0244_fa_0059v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0244"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0244_fa_0059v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0245",
+      "@type" : "sc:Canvas",
+      "label" : "59v.[02.wl.0000]",
+      "width" : 1950,
+      "height" : 2741,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0245",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0245",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0245_fa_0059v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1950,
+          "height" : 2741
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0245"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0245_fa_0059v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0246",
+      "@type" : "sc:Canvas",
+      "label" : "60r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0246",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0246",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0246_fa_0060r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0246"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0246_fa_0060r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0247",
+      "@type" : "sc:Canvas",
+      "label" : "60r.[02.wl.0000]",
+      "width" : 1960,
+      "height" : 2741,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0247",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0247",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0247_fa_0060r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1960,
+          "height" : 2741
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0247"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0247_fa_0060r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0248",
+      "@type" : "sc:Canvas",
+      "label" : "60v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0248",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0248",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0248_fa_0060v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0248"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0248_fa_0060v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0249",
+      "@type" : "sc:Canvas",
+      "label" : "60v.[02.wl.0000]",
+      "width" : 1968,
+      "height" : 2713,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0249",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0249",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0249_fa_0060v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1968,
+          "height" : 2713
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0249"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0249_fa_0060v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0250",
+      "@type" : "sc:Canvas",
+      "label" : "61r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0250",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0250",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0250_fa_0061r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0250"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0250_fa_0061r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0251",
+      "@type" : "sc:Canvas",
+      "label" : "61r.[02.wl.0000]",
+      "width" : 1968,
+      "height" : 2719,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0251",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0251",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0251_fa_0061r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1968,
+          "height" : 2719
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0251"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0251_fa_0061r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0252",
+      "@type" : "sc:Canvas",
+      "label" : "61v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0252",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0252",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0252_fa_0061v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0252"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0252_fa_0061v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0253",
+      "@type" : "sc:Canvas",
+      "label" : "61v.[02.wl.0000]",
+      "width" : 1948,
+      "height" : 2735,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0253",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0253",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0253_fa_0061v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1948,
+          "height" : 2735
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0253"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0253_fa_0061v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0254",
+      "@type" : "sc:Canvas",
+      "label" : "62r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0254",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0254",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0254_fa_0062r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0254"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0254_fa_0062r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0255",
+      "@type" : "sc:Canvas",
+      "label" : "62r.[02.wl.0000]",
+      "width" : 1968,
+      "height" : 2743,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0255",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0255",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0255_fa_0062r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1968,
+          "height" : 2743
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0255"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0255_fa_0062r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0256",
+      "@type" : "sc:Canvas",
+      "label" : "62v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0256",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0256",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0256_fa_0062v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0256"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0256_fa_0062v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0257",
+      "@type" : "sc:Canvas",
+      "label" : "62v.[02.wl.0000]",
+      "width" : 1964,
+      "height" : 2724,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0257",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0257",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0257_fa_0062v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1964,
+          "height" : 2724
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0257"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0257_fa_0062v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0258",
+      "@type" : "sc:Canvas",
+      "label" : "63r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0258",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0258",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0258_fa_0063r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0258"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0258_fa_0063r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0259",
+      "@type" : "sc:Canvas",
+      "label" : "63r.[02.wl.0000]",
+      "width" : 1950,
+      "height" : 2736,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0259",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0259",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0259_fa_0063r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1950,
+          "height" : 2736
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0259"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0259_fa_0063r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0260",
+      "@type" : "sc:Canvas",
+      "label" : "63v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0260",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0260",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0260_fa_0063v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0260"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0260_fa_0063v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0261",
+      "@type" : "sc:Canvas",
+      "label" : "63v.[02.wl.0000]",
+      "width" : 1948,
+      "height" : 2705,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0261",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0261",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0261_fa_0063v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1948,
+          "height" : 2705
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0261"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0261_fa_0063v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0262",
+      "@type" : "sc:Canvas",
+      "label" : "64r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0262",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0262",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0262_fa_0064r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0262"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0262_fa_0064r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0263",
+      "@type" : "sc:Canvas",
+      "label" : "64r.[02.wl.0000]",
+      "width" : 1964,
+      "height" : 2688,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0263",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0263",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0263_fa_0064r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1964,
+          "height" : 2688
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0263"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0263_fa_0064r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0264",
+      "@type" : "sc:Canvas",
+      "label" : "64v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0264",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0264",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0264_fa_0064v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0264"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0264_fa_0064v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0265",
+      "@type" : "sc:Canvas",
+      "label" : "64v.[02.wl.0000]",
+      "width" : 1925,
+      "height" : 2719,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0265",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0265",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0265_fa_0064v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1925,
+          "height" : 2719
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0265"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0265_fa_0064v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0266",
+      "@type" : "sc:Canvas",
+      "label" : "65r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0266",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0266",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0266_fa_0065r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0266"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0266_fa_0065r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0267",
+      "@type" : "sc:Canvas",
+      "label" : "65r.[02.wl.0000]",
+      "width" : 1932,
+      "height" : 2698,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0267",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0267",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0267_fa_0065r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1932,
+          "height" : 2698
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0267"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0267_fa_0065r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0268",
+      "@type" : "sc:Canvas",
+      "label" : "65v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0268",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0268",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0268_fa_0065v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0268"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0268_fa_0065v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0269",
+      "@type" : "sc:Canvas",
+      "label" : "65v.[02.wl.0000]",
+      "width" : 1984,
+      "height" : 2720,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0269",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0269",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0269_fa_0065v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1984,
+          "height" : 2720
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0269"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0269_fa_0065v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0270",
+      "@type" : "sc:Canvas",
+      "label" : "66r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0270",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0270",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0270_fa_0066r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0270"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0270_fa_0066r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0271",
+      "@type" : "sc:Canvas",
+      "label" : "66r.[02.wl.0000]",
+      "width" : 1942,
+      "height" : 2735,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0271",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0271",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0271_fa_0066r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1942,
+          "height" : 2735
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0271"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0271_fa_0066r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0272",
+      "@type" : "sc:Canvas",
+      "label" : "66v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0272",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0272",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0272_fa_0066v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0272"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0272_fa_0066v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0273",
+      "@type" : "sc:Canvas",
+      "label" : "66v.[02.wl.0000]",
+      "width" : 1943,
+      "height" : 2728,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0273",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0273",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0273_fa_0066v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1943,
+          "height" : 2728
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0273"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0273_fa_0066v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0274",
+      "@type" : "sc:Canvas",
+      "label" : "67r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0274",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0274",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0274_fa_0067r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0274"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0274_fa_0067r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0275",
+      "@type" : "sc:Canvas",
+      "label" : "67r.[02.wl.0000]",
+      "width" : 1954,
+      "height" : 2694,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0275",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0275",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0275_fa_0067r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1954,
+          "height" : 2694
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0275"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0275_fa_0067r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0276",
+      "@type" : "sc:Canvas",
+      "label" : "67v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0276",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0276",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0276_fa_0067v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0276"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0276_fa_0067v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0277",
+      "@type" : "sc:Canvas",
+      "label" : "67v.[02.wl.0000]",
+      "width" : 1956,
+      "height" : 2712,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0277",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0277",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0277_fa_0067v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1956,
+          "height" : 2712
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0277"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0277_fa_0067v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0278",
+      "@type" : "sc:Canvas",
+      "label" : "68r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0278",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0278",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0278_fa_0068r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0278"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0278_fa_0068r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0279",
+      "@type" : "sc:Canvas",
+      "label" : "68r.[02.wl.0000]",
+      "width" : 1964,
+      "height" : 2688,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0279",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0279",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0279_fa_0068r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1964,
+          "height" : 2688
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0279"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0279_fa_0068r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0280",
+      "@type" : "sc:Canvas",
+      "label" : "68v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0280",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0280",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0280_fa_0068v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0280"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0280_fa_0068v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0281",
+      "@type" : "sc:Canvas",
+      "label" : "68v.[02.wl.0000]",
+      "width" : 1940,
+      "height" : 2735,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0281",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0281",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0281_fa_0068v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1940,
+          "height" : 2735
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0281"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0281_fa_0068v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 106,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0282",
+      "@type" : "sc:Canvas",
+      "label" : "69r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0282",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0282",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0282_fa_0069r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0282"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0282_fa_0069r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0283",
+      "@type" : "sc:Canvas",
+      "label" : "69r.[02.wl.0000]",
+      "width" : 1964,
+      "height" : 2706,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0283",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0283",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0283_fa_0069r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1964,
+          "height" : 2706
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0283"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0283_fa_0069r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0284",
+      "@type" : "sc:Canvas",
+      "label" : "69v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0284",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0284",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0284_fa_0069v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0284"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0284_fa_0069v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0285",
+      "@type" : "sc:Canvas",
+      "label" : "69v.[02.wl.0000]",
+      "width" : 1976,
+      "height" : 2759,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0285",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0285",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0285_fa_0069v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1976,
+          "height" : 2759
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0285"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0285_fa_0069v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0286",
+      "@type" : "sc:Canvas",
+      "label" : "70r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0286",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0286",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0286_fa_0070r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0286"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0286_fa_0070r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0287",
+      "@type" : "sc:Canvas",
+      "label" : "70r.[02.wl.0000]",
+      "width" : 1936,
+      "height" : 2699,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0287",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0287",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0287_fa_0070r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1936,
+          "height" : 2699
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0287"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0287_fa_0070r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0288",
+      "@type" : "sc:Canvas",
+      "label" : "70v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0288",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0288",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0288_fa_0070v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0288"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0288_fa_0070v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0289",
+      "@type" : "sc:Canvas",
+      "label" : "70v.[02.wl.0000]",
+      "width" : 1962,
+      "height" : 2729,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0289",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0289",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0289_fa_0070v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1962,
+          "height" : 2729
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0289"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0289_fa_0070v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0290",
+      "@type" : "sc:Canvas",
+      "label" : "71r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0290",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0290",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0290_fa_0071r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0290"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0290_fa_0071r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0291",
+      "@type" : "sc:Canvas",
+      "label" : "71r.[02.wl.0000]",
+      "width" : 1978,
+      "height" : 2713,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0291",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0291",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0291_fa_0071r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1978,
+          "height" : 2713
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0291"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0291_fa_0071r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0292",
+      "@type" : "sc:Canvas",
+      "label" : "71v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0292",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0292",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0292_fa_0071v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0292"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0292_fa_0071v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0293",
+      "@type" : "sc:Canvas",
+      "label" : "71v.[02.wl.0000]",
+      "width" : 1983,
+      "height" : 2726,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0293",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0293",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0293_fa_0071v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1983,
+          "height" : 2726
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0293"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0293_fa_0071v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 109,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0294",
+      "@type" : "sc:Canvas",
+      "label" : "72r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0294",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0294",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0294_fa_0072r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0294"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0294_fa_0072r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0295",
+      "@type" : "sc:Canvas",
+      "label" : "72r.[02.wl.0000]",
+      "width" : 1961,
+      "height" : 2730,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0295",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0295",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0295_fa_0072r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1961,
+          "height" : 2730
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0295"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0295_fa_0072r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 107,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0296",
+      "@type" : "sc:Canvas",
+      "label" : "72v",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0296",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0296",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0296_fa_0072v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0296"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0296_fa_0072v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0297",
+      "@type" : "sc:Canvas",
+      "label" : "72v.[02.wl.0000]",
+      "width" : 1969,
+      "height" : 2716,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0297",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0297",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0297_fa_0072v.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1969,
+          "height" : 2716
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0297"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0297_fa_0072v.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0298",
+      "@type" : "sc:Canvas",
+      "label" : "1r",
+      "width" : 1887,
+      "height" : 2517,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0298",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0298",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0298_sy_0001r.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1887,
+          "height" : 2517
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0298"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0298_sy_0001r.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0299",
+      "@type" : "sc:Canvas",
+      "label" : "1r.[02.wl.0000]",
+      "width" : 1982,
+      "height" : 2731,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0299",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0299",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0299_sy_0001r.%5B02.wl.0000%5D.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1982,
+          "height" : 2731
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0299"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0299_sy_0001r.%5B02.wl.0000%5D.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 108,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0300",
+      "@type" : "sc:Canvas",
+      "label" : "1v",
+      "width" : 1895,
+      "height" : 2518,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0300",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0300",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0300_sy_0001v.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1895,
+          "height" : 2518
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0300"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0300_sy_0001v.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0301",
+      "@type" : "sc:Canvas",
+      "label" : "risguardia.posteriore",
+      "width" : 1950,
+      "height" : 2594,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0301",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0301",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0301_ye_risguardia.posteriore.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1950,
+          "height" : 2594
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0301"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0301_ye_risguardia.posteriore.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0302",
+      "@type" : "sc:Canvas",
+      "label" : "dorso",
+      "width" : 655,
+      "height" : 2568,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0302",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0302",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0302_yh_dorso.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 655,
+          "height" : 2568
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0302"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0302_yh_dorso.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 38,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0303",
+      "@type" : "sc:Canvas",
+      "label" : "taglio.centrale",
+      "width" : 602,
+      "height" : 2514,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0303",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0303",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0303_yl_taglio.centrale.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 602,
+          "height" : 2514
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0303"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0303_yl_taglio.centrale.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 35,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0304",
+      "@type" : "sc:Canvas",
+      "label" : "taglio.inferiore",
+      "width" : 602,
+      "height" : 1979,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0304",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0304",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0304_yn_taglio.inferiore.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 602,
+          "height" : 1979
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0304"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0304_yn_taglio.inferiore.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 45,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0305",
+      "@type" : "sc:Canvas",
+      "label" : "taglio.superiore",
+      "width" : 602,
+      "height" : 1979,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0305",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0305",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0305_yp_taglio.superiore.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 602,
+          "height" : 1979
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0305"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0305_yp_taglio.superiore.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 45,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0306",
+      "@type" : "sc:Canvas",
+      "label" : "piatto.posteriore",
+      "width" : 1997,
+      "height" : 2662,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0306",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0306",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0306_za_piatto.posteriore.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 1997,
+          "height" : 2662
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0306"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0306_za_piatto.posteriore.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 112,
+        "height" : 150
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0307",
+      "@type" : "sc:Canvas",
+      "label" : "colorchecker",
+      "width" : 3615,
+      "height" : 2750,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0307",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0307",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0307_zx_colorchecker.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 3615,
+          "height" : 2750
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0307"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0307_zx_colorchecker.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 150,
+        "height" : 114
+      },
+      "viewingHint" : "non-paged"
+    }, {
+      "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0308",
+      "@type" : "sc:Canvas",
+      "label" : "scala.millimetrica",
+      "width" : 3580,
+      "height" : 2773,
+      "images" : [ {
+        "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/anno0308",
+        "@type" : "oa:Annotation",
+        "motivation" : "sc:painting",
+        "resource" : {
+          "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/res/img0308",
+          "@type" : "dctypes:Image",
+          "format" : "image/jpeg",
+          "service" : {
+            "@context" : "http://iiif.io/api/image/2/context.json",
+            "@id" : "https://digi.vatlib.it/iiifimage/MSS_Vat.lat.3195/Vat.lat.3195_0308_zz_scala.millimetrica.jp2",
+            "profile" : "http://iiif.io/api/image/2/level2.json"
+          },
+          "width" : 3580,
+          "height" : 2773
+        },
+        "on" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0308"
+      } ],
+      "thumbnail" : {
+        "@id" : "https://digi.vatlib.it/pub/digit/MSS_Vat.lat.3195/thumb/Vat.lat.3195_0308_zz_scala.millimetrica.tif.jpg",
+        "@type" : "dctypes:Image",
+        "format" : "image/jpeg",
+        "width" : 150,
+        "height" : 116
+      },
+      "viewingHint" : "non-paged"
+    } ],
+    "viewingDirection" : "left-to-right",
+    "viewingHint" : "paged"
+  } ],
+  "structures" : [ {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0",
+    "@type" : "sc:Range",
+    "label" : "Petrarca, Francesco, 1304-1374: Rerum vulgarium fragmenta; 1366-1374",
+    "ranges" : [ "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0-0", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0-1", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0-2" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0-0",
+    "@type" : "sc:Range",
+    "label" : "Legatura",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0001" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0-1",
+    "@type" : "sc:Range",
+    "label" : "1av-49r. 53r-72v Petrarca, Francesco: Rerum vulgarium fragmenta",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0008", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0009", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0010", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0011", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0012", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0013", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0014", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0015", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0016", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0017", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0018", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0019", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0020", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0021", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0022", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0023", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0024", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0025", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0026", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0027", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0028", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0029", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0030", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0031", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0032", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0033", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0034", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0035", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0036", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0037", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0038", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0039", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0040", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0041", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0042", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0043", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0044", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0045", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0046", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0047", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0048", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0049", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0050", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0051", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0052", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0053", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0054", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0055", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0056", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0057", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0058", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0059", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0060", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0061", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0062", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0063", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0064", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0065", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0066", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0067", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0068", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0069", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0070", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0071", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0072", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0073", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0074", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0075", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0076", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0077", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0078", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0079", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0080", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0081", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0082", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0083", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0084", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0085", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0086", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0087", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0088", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0089", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0090", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0091", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0092", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0093", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0094", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0095", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0096", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0097", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0098", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0099", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0100", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0101", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0102", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0103", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0104", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0105", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0106", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0107", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0108", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0109", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0110", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0111", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0112", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0113", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0114", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0115", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0116", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0117", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0118", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0119", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0120", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0121", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0122", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0123", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0124", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0125", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0126", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0127", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0128", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0129", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0130", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0131", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0132", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0133", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0134", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0135", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0136", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0137", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0138", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0139", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0140", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0141", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0142", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0143", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0144", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0145", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0146", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0147", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0148", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0149", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0150", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0151", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0152", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0153", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0154", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0155", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0156", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0157", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0158", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0159", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0160", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0161", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0162", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0163", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0164", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0165", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0166", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0167", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0168", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0169", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0170", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0171", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0172", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0173", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0174", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0175", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0176", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0177", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0178", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0179", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0180", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0181", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0182", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0183", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0184", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0185", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0186", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0187", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0188", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0189", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0190", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0191", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0192", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0193", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0194", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0195", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0196", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0197", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0198", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0199", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0200", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0201", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0202", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0203", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0204", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0205", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0206", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0207", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0208", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0209", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0210", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0211", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0212", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0213", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0214", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0215", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0216", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0217", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0218", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0219", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0220", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0221", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0222", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0223", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0224", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0225", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0226", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0227", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0228", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0229", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0230", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0231", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0232", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0233", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0234", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0235", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0236", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0237", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0238", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0239", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0240", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0241", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0242", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0243", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0244", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0245", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0246", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0247", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0248", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0249", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0250", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0251", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0252", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0253", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0254", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0255", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0256", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0257", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0258", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0259", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0260", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0261", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0262", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0263", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0264", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0265", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0266", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0267", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0268", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0269", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0270", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0271", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0272", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0273", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0274", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0275", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0276", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0277", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0278", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0279", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0280", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0281", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0282", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0283", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0284", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0285", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0286", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0287", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0288", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0289", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0290", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0291", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0292", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0293", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0294", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0295", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0296", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0297" ],
+    "ranges" : [ "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0-1-0" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0-1-0",
+    "@type" : "sc:Range",
+    "label" : "1av-1bv Tabula",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0-1",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0008", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0009", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0010", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0011", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0012", "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0013" ]
+  }, {
+    "@id" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0-2",
+    "@type" : "sc:Range",
+    "label" : "Legatura",
+    "within" : "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/range/r0",
+    "canvases" : [ "https://digi.vatlib.it/iiif/MSS_Vat.lat.3195/canvas/p0306" ]
+  } ],
+  "seeAlso" : [ "https://digi.vatlib.it/mss/detail/Vat.lat.3195" ]
+}

--- a/spec/fixtures/tei/Ott.gr.85.xml
+++ b/spec/fixtures/tei/Ott.gr.85.xml
@@ -1,0 +1,1778 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ino:request xmlns:ino="http://namespaces.softwareag.com/tamino/response2">
+<ino:object>
+<TEI.2 inoid="207451" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850001r-v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>1r-v</locus><author authorityID="33163" scan="@33163" type="internal"><alias><authorityAuthor date="sec. VII" rif="aut" type="person">Leontius Constantinopolitanus,</authorityAuthor><authorityAuthor date="sec. VII" rif="see" type="person">Leontius Presbyter Constantinopolitanus,</authorityAuthor></alias></author><title scan="@1In nativitatem Christi_supplied" type="supplied" value="In nativitatem Christi">In nativitatem Christi</title><incipit scan="@2μάγοι οἱ μάγοι_" value="μάγοι οἱ μάγοι">μάγοι οἱ μάγοι</incipit><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fragmentum.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>C. Datema, Leontius, presbyter of Constantinople, and an unpublished homily of Ps. Chrysostom on Christmas | (BHG 1914i/1914k), in Jahrbuch der Österreichischen Byzantinistik 39 (1989) 67-79.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="12/12/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">07/11/2017</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="12/12/2016">A.Berloco</persName><persName n="12/12/2016">A.Berloco</persName>
+					<persName n="07/11/2017">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="207476" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850061r-v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>61r-v</locus><author authorityID="465" scan="@465" type="internal"><alias><authorityAuthor date="347-407" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Chrysostomus,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Johannes Chrysostomus,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Crisostomo, Giovanni,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Giovanni Crisostomo,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Giovanni Boccadoro,</authorityAuthor></alias></author><title scan="@1De baptismo Christi_supplied" type="supplied" value="De baptismo Christi">De baptismo Christi</title><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fragmentum.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="13/12/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">07/11/2017</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="13/12/2016">A.Berloco</persName>
+					<persName n="07/11/2017">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184291" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850230r-v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>230r-v</locus><author authorityID="28332" scan="@28332" type="internal"><alias><authorityAuthor date="c. 330-390" rif="aut" title="s.," type="person">Gregorius Nazianzenus,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorius Constantinopolitanus,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorio di Nazianzo,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorio il Teologo,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorio Nazianzeno,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorius Theologus,</authorityAuthor></alias></author><title scan="@1In sanctum Pascha et in tarditatem_supplied" type="supplied" value="In sanctum Pascha et in tarditatem">In sanctum Pascha et in tarditatem</title><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">&lt;Fragmentum&gt;. Fol. 230 λόγ. ΜΗ´ .. - τοῦ ΓΡΗΓΟΡΙΟΥ... Ναζιανζοῦ (alia manu recentiori) εἰς ἅγιον Πάσχα.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">07/11/2017</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName><persName n="28/11/2016">A.Berloco</persName><persName n="13/12/2016">A.Berloco</persName><persName n="13/12/2016">A.Berloco</persName><persName n="18/12/2016">A.Berloco</persName>
+					<persName n="07/11/2017">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="207462" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850231r-234v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>231r-234v</locus><author authorityID="28332" scan="@28332" type="internal"><alias><authorityAuthor date="c. 330-390" rif="aut" title="s.," type="person">Gregorius Nazianzenus,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorius Constantinopolitanus,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorio di Nazianzo,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorio il Teologo,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorio Nazianzeno,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorius Theologus,</authorityAuthor></alias></author><title scan="@1In sanctum Pascha_supplied" type="supplied" value="In sanctum Pascha">In sanctum Pascha</title><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">&lt;Fragmentum&gt;. Folio 234v abrumpitur sermo ad verba ἀκοῆς ὡς εὐσεβέστερον.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="13/12/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">07/11/2017</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="18/12/2016">A.Berloco</persName>
+					<persName n="07/11/2017">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="183855" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="y"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850000" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><p>Miscellanea homiletica.</p><msItem><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Principio et fine caret. Folium 1 incipit a verbis μάγοι οἱ μάγοι· οὐκ ἔτι... [...] Post folium 54 aliquid deest. Deinde sequitur pars sermonis XVI.</note><name authorityID="31269" role="owner" scan="@31269"><alias><authorityAuthor rif="aut" type="person">Altemps (famiglia)</authorityAuthor></alias></name><origDate notAfter="1025" notBefore="976">sec. X-XI</origDate></msItem></msContents><physDesc><support><p>membr.</p></support><dimensions><height>306</height><width>210</width></dimensions><extent>ff. 234</extent></physDesc><history><provenance><p>Folium &quot;a&quot; habet consueta Altaempsiana, et &quot;n. 86&quot;.</p></provenance></history><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 51-53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="22/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">07/11/2017</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="12/12/2016">A.Berloco</persName>
+					<persName n="07/11/2017">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="121959" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850007v-17v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>7v-17v</locus><author authorityID="16197" scan="@16197" type="internal"><alias><authorityAuthor date="c. 335-c. 394" rif="aut" title="s.," type="person">Gregorius Nyssenus,</authorityAuthor></alias></author><title scan="@1Oratio in diem natalem Christi_supplied" type="supplied" value="Oratio in diem natalem Christi">Oratio in diem natalem Christi</title><uniformTitle authorityID="40752" scan="@40752" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Oratio in diem natalem Christi (Gregorius Nyssenus, s., c. 335-c. 394)">Oratio in diem natalem Christi (Gregorius Nyssenus, s., c. 335-c. 394)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 7v Τοῦ.. ΓΡΗΓΟΡΙΟΥ.. Νύσης εἰς τὴν ἡμέραν τῶν γενεθλίων τοῦ κυρίου λόγ. Ζ´.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 51.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="06/09/2013"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="18/12/2015">D.Lionetti</persName><persName n="22/12/2015">D.Lionetti</persName><persName n="22/12/2015">D.Lionetti</persName><persName n="29/12/2015">D.Lionetti</persName><persName n="29/12/2015">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="25/11/2016">A.Berloco</persName><persName n="25/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="121960" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850021v-24v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>21v-24v</locus><author authorityID="33322" scan="@33322" type="internal"><alias><authorityAuthor date="sec. VIII" rif="aut" type="person">Iohannes Euboeensis,</authorityAuthor><authorityAuthor date="sec. VIII" rif="see" type="person">Euboea, Iohannes de</authorityAuthor></alias></author><title scan="@1Homilia in sanctos Innocentes_supplied" type="supplied" value="Homilia in sanctos Innocentes">Homilia in sanctos Innocentes</title><uniformTitle authorityID="33267" scan="@33267" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Homilia in s. Innocentes (Iohannes Euboeensis, sec. VIII)">Homilia in s. Innocentes (Iohannes Euboeensis, sec. VIII)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Homilia in sanctos Innocentes (Iohannes Euboeensis, sec. VIII)">Homilia in sanctos Innocentes (Iohannes Euboeensis, sec. VIII)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 21v ΙΩΑΝΝΟΥ.. πρεσβ. Εὐοίας.. εἰς τὰ ἅγια Νήπια λόγ. Θ´.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="06/09/2013"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="12/12/2013">D.Lionetti</persName><persName n="18/12/2015">D.Lionetti</persName><persName n="22/12/2015">D.Lionetti</persName><persName n="22/12/2015">D.Lionetti</persName><persName n="29/12/2015">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="25/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="121961" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850038r-45v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>38r-45v</locus><author authorityID="28332" scan="@28332" type="internal"><alias><authorityAuthor date="c. 330-390" rif="aut" title="s.," type="person">Gregorius Nazianzenus,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorius Constantinopolitanus,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorio di Nazianzo,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorio il Teologo,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorio Nazianzeno,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorius Theologus,</authorityAuthor></alias></author><title scan="@1In sancta lumina_supplied" type="supplied" value="In sancta lumina">In sancta lumina</title><uniformTitle authorityID="37085" scan="@37085" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In sancta Lumina (Gregorius Nazianzenus, s., c. 330-390)">In sancta Lumina (Gregorius Nazianzenus, s., c. 330-390)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Orationes (Gregorius Nazianzenus, s., c. 330-390). 39, In sancta Lumina">Orationes (Gregorius Nazianzenus, s., c. 330-390). 39, In sancta Lumina</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 38 ..ΓΡΗΓΟΡΙΟΥ.. Ναζιανζοῦ.. εἰς τὰ Φῶτα - λόγ. ΙΑ´. Fol. 46 Τοῦ αὐτοῦ εἰς τὸ Βάπτισμα λόγ. ΙΒ´.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="06/09/2013"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="06/09/2013">D.Lionetti</persName><persName n="22/12/2015">D.Lionetti</persName><persName n="29/12/2015">D.Lionetti</persName><persName n="29/12/2015">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="25/11/2016">A.Berloco</persName><persName n="25/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="129921" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850018r-21v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>18r-21v</locus><author authorityID="3282" scan="@3282" type="internal"><alias><authorityAuthor date="m. c. 446" rif="aut" title="s., arciv. di Costantinopoli," type="person">Proclus,</authorityAuthor><authorityAuthor date="m. c. 446" rif="see" title="s., arciv. di Costantinopoli," type="person">Proclus Constantinopolitanus,</authorityAuthor></alias></author><title scan="@1In sanctum Stephanum homilia_supplied" type="supplied" value="In sanctum Stephanum homilia">In sanctum Stephanum homilia</title><uniformTitle authorityID="33266" scan="@33266" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In laudem s. Stephani (Proclus, s., arciv. di Costantinopoli, m. c. 446)">In laudem s. Stephani (Proclus, s., arciv. di Costantinopoli, m. c. 446)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Homiliae. In laudem s. Stephani (Proclus, s., arciv. di Costantinopoli, m. c. 446)">Homiliae. In laudem s. Stephani (Proclus, s., arciv. di Costantinopoli, m. c. 446)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 18 ΠΡΟΚΛΟΥ ἀρχιεπ. Κπ̅ολ.. εἰς τὸν ἅγιον Στέφανον πρωτομάρτυρα λόγ. Η´.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="12/12/2013"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">25/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="22/12/2015">D.Lionetti</persName><persName n="22/12/2015">D.Lionetti</persName><persName n="29/12/2015">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="25/11/2016">A.Berloco</persName>
+					<persName n="25/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="129922" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850025r-38r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>25r-38r</locus><author authorityID="16197" scan="@16197" type="internal"><alias><authorityAuthor date="c. 335-c. 394" rif="aut" title="s.," type="person">Gregorius Nyssenus,</authorityAuthor></alias></author><title scan="@1In Basilium fratrem_supplied" type="supplied" value="In Basilium fratrem">In Basilium fratrem</title><uniformTitle authorityID="40753" scan="@40753" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In Basilium fratrem (Gregorius Nyssenus, s., c. 335-c. 394)">In Basilium fratrem (Gregorius Nyssenus, s., c. 335-c. 394)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 25 .. ΓΡΗΓΟΡΙΟΥ.. Νύσης.. εἰς τὸν ὅσ.. Βασίλειον λόγ. Ι´.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="12/12/2013"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="22/12/2015">D.Lionetti</persName><persName n="22/12/2015">D.Lionetti</persName><persName n="29/12/2015">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="25/11/2016">A.Berloco</persName><persName n="25/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="183872" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850002r-7v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>2r-7v</locus><author authorityID="23211" scan="@23211" type="internal"><alias><authorityAuthor date="292-373." formal="Opere spurie e dubbie" rif="aut" title="s., patriarca di Alessandria," type="person">Athanasius,</authorityAuthor></alias></author><title scan="@1Sermo de descriptione Deiparae_supplied" type="supplied" value="Sermo de descriptione Deiparae">Sermo de descriptione Deiparae</title><uniformTitle authorityID="40751" scan="@40751" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Sermo de descriptione Deiparae (Athanasius, s., patriarca di Alessandria, 292-373. Opere spurie e dubbie)">Sermo de descriptione Deiparae (Athanasius, s., patriarca di Alessandria, 292-373. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 2 ΑΘΑΝΑΣΙΟΥ Ἀλεξ.. εἰς τὴν ἀπογραφὴν τῆς Θεοτόκου λόγ. ϛ´ (sermo VI); unde liquet quinque praecessisse sermones.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 51.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="22/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="23/12/2015">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="25/11/2016">A.Berloco</persName><persName n="25/11/2016">A.Berloco</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184266" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850061v-66v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>61v-66v</locus><author authorityID="40755" scan="@40755" type="internal"><alias><authorityAuthor date="f. 570-593" rif="aut" title="vesc. di Antiochia," type="person">Gregorius Antiochenus,</authorityAuthor></alias></author><title scan="@1Homilia II In s. Theophania_supplied" type="supplied" value="Homilia II In s. Theophania">Homilia II In s. Theophania</title><uniformTitle authorityID="40756" scan="@40756" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Homilia II in s. Theophania (Gregorius Antiochenus, vesc. di Antiochia, f. 570-593)">Homilia II in s. Theophania (Gregorius Antiochenus, vesc. di Antiochia, f. 570-593)</authorityTitleSeries><authorityTitleSeries rif="see_also" type="uniform" value="In s. Theophania (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)">In s. Theophania (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 61v incipit λόγος ΙΖ´. ΓΡΗΓΟΡΙΟΥ πρεσβυτ. Ἀντιοχείας εἰς τὸ - Οὗτός ἐστιν ὁ Υἱὸς...</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="25/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184268" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850067r-72r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>67r-72r</locus><author authorityID="33269" scan="@33269" type="internal"><alias><authorityAuthor date="m. 395" rif="aut" title="s., vesc. di Iconium," type="person">Amphilochius,</authorityAuthor><authorityAuthor date="m. 395" rif="see" title="s., vesc. di Iconium," type="person">Amphilochius Iconiensis,</authorityAuthor></alias></author><title scan="@1In occursum Domini_supplied" type="supplied" value="In occursum Domini">In occursum Domini</title><uniformTitle authorityID="33270" scan="@33270" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Oratio in Occursum Domini (Amphilochius, s., vesc. di Iconium, m. 395)">Oratio in Occursum Domini (Amphilochius, s., vesc. di Iconium, m. 395)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Orationes. Oratio in Occursum Domini (Amphilochius, s., vesc. di Iconium, m. 395)">Orationes. Oratio in Occursum Domini (Amphilochius, s., vesc. di Iconium, m. 395)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 67 λόγ. ΙΗ´ ΑΜΦΙΛΟXΙΟΥ ἐπισκόπ. Ἰκονίου.. εἰς τὴν Ἀπαντὴν (sic) τοῦ κυρίου.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="25/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184269" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850072r-76v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>72r-76v</locus><author authorityID="40757" scan="@40757" type="internal"><alias><authorityAuthor date="sec. VI" rif="aut" type="person">Timotheus Hierosolymitanus,</authorityAuthor></alias></author><title scan="@1Sermo in Crucem et Transfigurationem_supplied" type="supplied" value="Sermo in Crucem et Transfigurationem">Sermo in Crucem et Transfigurationem</title><uniformTitle authorityID="40758" scan="@40758" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Sermo in Crucem et Transfigurationem (Timotheus Hierosolymitanus, sec. VI)">Sermo in Crucem et Transfigurationem (Timotheus Hierosolymitanus, sec. VI)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="In crucem et in Transfigurationem">In crucem et in Transfigurationem</authorityTitleSeries><authorityTitleSeries rif="see_also" type="uniform" value="Homilia in Transfigurationem et crucem (Leontius Constantinopolitanus, sec. VII. Opere spurie e dubbie))">Homilia in Transfigurationem et crucem (Leontius Constantinopolitanus, sec. VII. Opere spurie e dubbie))</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 72 λόγ. ΙΘ´ ΤΙΜΟΘΕΟΥ πρεσβ. Ἰεροσολύμων.. εἰς τὸ... - Νῦν ἀπολύεις τὸν δοῦλόν σου..</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="25/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184270" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850076v-89v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>76v-89v</locus><author authorityID="11482" scan="@11482" type="internal"><alias><authorityAuthor date="m. c. 311." formal="Opere spurie e dubbie" rif="aut" title="s., vesc. di Olympus," type="person">Methodius,</authorityAuthor></alias></author><title scan="@1Sermo de Simeone et Anna_supplied" type="supplied" value="Sermo de Simeone et Anna">Sermo de Simeone et Anna</title><uniformTitle authorityID="40759" scan="@40759" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Sermo de Simeone et Anna (Methodius, s., vesc. di Olympus, m. c. 311. Opere spurie e dubbie)">Sermo de Simeone et Anna (Methodius, s., vesc. di Olympus, m. c. 311. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 76v λόγ. Κ´.. ΜΕΘΟΔΙΟΥ ἐπισκόπ. Πατάρων... εἰς τὴν Θεοτόκον.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="25/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184271" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850089v-93v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>89v-93v</locus><author authorityID="6376" scan="@6376" type="internal"><alias><authorityAuthor date="m. 444" rif="aut" title="s., patriarca di Alessandria," type="person">Cyrillus,</authorityAuthor><authorityAuthor date="m. 444" rif="see" title="s.," type="person">Cyrillus Alexandrinus,</authorityAuthor><authorityAuthor date="m. 444" rif="see" title="s., patriarca di Alessandria," type="person">Cirillo,</authorityAuthor></alias></author><title scan="@1Commentarii in Lucam. Homiliae III et IV_supplied" type="supplied" value="Commentarii in Lucam. Homiliae III et IV">Commentarii in Lucam. Homiliae III et IV</title><uniformTitle authorityID="40760" scan="@40760" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Homiliae (Cyrillus, s., patriarca di Alessandria, m. 444). 12, In occursum Domini">Homiliae (Cyrillus, s., patriarca di Alessandria, m. 444). 12, In occursum Domini</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Commentarii in Lucam (Cyrillus, s., patriarca di Alessandria, m. 444). 1, Homiliae 3 et 4">Commentarii in Lucam (Cyrillus, s., patriarca di Alessandria, m. 444). 1, Homiliae 3 et 4</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 89v (λόγ.) ΚΑ´.. ΚΥΡΙΛΛΟΥ.. Ἀλεξανδρείας εἰς τὴν ὑπαπαντὴν τοῦ κυρίου...</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="25/11/2016">A.Berloco</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184272" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850093v-97v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>93v-97v</locus><author authorityID="36302" scan="@36302" type="internal"><alias><authorityAuthor date="sec. V" rif="aut" type="person">Hesychius Hierosolymitanus,</authorityAuthor></alias></author><title scan="@1Homiliae in Hypapanten I et II_supplied" type="supplied" value="Homiliae in Hypapanten I et II">Homiliae in Hypapanten I et II</title><uniformTitle authorityID="40761" scan="@40761" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Homilia I in Hypapanten (Hesychius Hierosolymitanus, sec. V)">Homilia I in Hypapanten (Hesychius Hierosolymitanus, sec. V)</authorityTitleSeries></alias></uniformTitle><uniformTitle authorityID="40762" scan="@40762" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Homilia II in Hypapanten (Hesychius Hierosolymitanus, sec. V)">Homilia II in Hypapanten (Hesychius Hierosolymitanus, sec. V)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 93v (λόγ.) ΚΒ´ ΗΣΥΧΙΟΥ πρεσβ.. εἰς τὴν ὑπαπαντὴν τοῦ Κυρίου..</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="25/11/2016">A.Berloco</persName><persName n="25/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184273" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850097v-100r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>97v-100r</locus><author authorityID="33304" scan="@33304" type="internal"><alias><authorityAuthor date="sec. V-VII." formal="Opere spurie e dubbie" rif="aut" type="person">Eusebius Alexandrinus,</authorityAuthor></alias></author><title scan="@1In secundum adventum Domini_supplied" type="supplied" value="In secundum adventum Domini">In secundum adventum Domini</title><uniformTitle authorityID="40777" scan="@40777" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Sermones (Eusebius Alexandrinus, sec. V-VII. Opere spurie e dubbie). 20, In secundum adventum Domini">Sermones (Eusebius Alexandrinus, sec. V-VII. Opere spurie e dubbie). 20, In secundum adventum Domini</authorityTitleSeries><authorityTitleSeries rif="see_also" type="uniform" value="In secundum adventum Domini (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)">In secundum adventum Domini (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 97v λόγ. ΚΓ´.. ΕΥΣΕΒΙΟΥ... Ἀλεξανδρείας εἰς τὴν δεύτεραν παρουσίαν τοῦ Κυρίου..</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="11/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184275" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850100r-105r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>100r-105r</locus><author authorityID="16197" scan="@16197" type="internal"><alias><authorityAuthor date="c. 335-c. 394" rif="aut" title="s.," type="person">Gregorius Nyssenus,</authorityAuthor></alias></author><title scan="@1De sancto Theodoro_supplied" type="supplied" value="De sancto Theodoro">De sancto Theodoro</title><uniformTitle authorityID="40778" scan="@40778" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="De s. Theodoro (Gregorius Nyssenus, s., c. 335-c. 394)">De s. Theodoro (Gregorius Nyssenus, s., c. 335-c. 394)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Oratio laudatoria s. ac magni Martyris Theodori (Gregorius Nyssenus, s., c. 335-c. 394)">Oratio laudatoria s. ac magni Martyris Theodori (Gregorius Nyssenus, s., c. 335-c. 394)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 100 λόγ. ΚΔ´.. ΓΡΗΓΟΡΙΟΥ.. Νύσης εἰς Θεόδωρον τὸν μάρτυρα.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184277" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850117v-120r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>117v-120r</locus><author authorityID="4473" scan="@4473" type="internal"><alias><authorityAuthor date="347-407." formal="Opere spurie e dubbie" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor></alias></author><title scan="@1In Annuntiationem beatae virginis_supplied" type="supplied" value="In Annuntiationem beatae virginis">In Annuntiationem beatae virginis</title><uniformTitle authorityID="40743" scan="@40743" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In Annuntiationem beatae virginis (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)">In Annuntiationem beatae virginis (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)</authorityTitleSeries><authorityTitleSeries rif="see_also" type="uniform" value="Homilia III in Annuntiatione virginis Mariae (Gregorius Thaumaturgus, s., vesc. di Neocesarea, c. 213-c. 270. Opere spurie e dubbie)">Homilia III in Annuntiatione virginis Mariae (Gregorius Thaumaturgus, s., vesc. di Neocesarea, c. 213-c. 270. Opere spurie e dubbie)</authorityTitleSeries><authorityTitleSeries rif="see_also" type="uniform" value="Sermo in Annuntiationem gloriosissimae Dominae nostrae Deiparae (Proclus, s., arciv. di Costantinopoli, m. c. 446. Opere spurie e dubbie)">Sermo in Annuntiationem gloriosissimae Dominae nostrae Deiparae (Proclus, s., arciv. di Costantinopoli, m. c. 446. Opere spurie e dubbie)</authorityTitleSeries><authorityTitleSeries rif="see_also" type="uniform" value="Sermones (Leo PP. I, Magnus, s., m. 461. Opere spurie e dubbie). 15">Sermones (Leo PP. I, Magnus, s., m. 461. Opere spurie e dubbie). 15</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="29/12/2015">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="08/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184278" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850120r-129r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>120r-129r</locus><author authorityID="22827" scan="@22827" type="internal"><alias><authorityAuthor date="c. 660-c. 720" rif="aut" title="s., arciv. di Gortyna," type="person">Andreas Cretensis,</authorityAuthor></alias></author><title scan="@1Homilia in annuntiationem beatae Mariae_supplied" type="supplied" value="Homilia in annuntiationem beatae Mariae">Homilia in annuntiationem beatae Mariae</title><uniformTitle authorityID="40781" scan="@40781" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In Annuntiationem beatae Mariae (Andreas Cretensis, s., arciv. di Gortyna, c. 660-c. 720)">In Annuntiationem beatae Mariae (Andreas Cretensis, s., arciv. di Gortyna, c. 660-c. 720)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Homiliae (Andreas Cretensis, s., arciv. di Gortyna, c. 660-c. 720). 5, In Annuntiationem beatae Mariae">Homiliae (Andreas Cretensis, s., arciv. di Gortyna, c. 660-c. 720). 5, In Annuntiationem beatae Mariae</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 120 λόγ. ΚΗ´.. τοῦ.. ΑΝΔΡΕΟΥ ἐπισκόπ. Κρήτης.. εἰς εὐαγγελισμὸν τῆς Θεοτόκου.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184280" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850129v-132v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>129v-132v</locus><author authorityID="40596" scan="@40596" type="internal"><alias><authorityAuthor date="c. 213-c. 270." formal="Opere spurie e dubbie" rif="aut" title="s., vesc. di Neocesarea," type="person">Gregorius Thaumaturgus,</authorityAuthor></alias></author><title scan="@1Homilia I in Annuntiationem virginis Mariae_supplied" type="supplied" value="Homilia I in Annuntiationem virginis Mariae">Homilia I in Annuntiationem virginis Mariae</title><uniformTitle authorityID="40783" scan="@40783" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Homilia I in Annuntiationem virginis Mariae (Gregorius Thaumaturgus, s., vesc. di Neocesarea, c. 213-c. 270. Opere spurie e dubbie)">Homilia I in Annuntiationem virginis Mariae (Gregorius Thaumaturgus, s., vesc. di Neocesarea, c. 213-c. 270. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 129v λόγ. ΚΘ´.. ΓΡΗΓΟΡΙΟΥ.. Νεοκαισαρίας Πόντου... εἰς εὐαγγελισμὸν τῆς Θεοτόκου.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184281" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850132v-140v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>132v-140v</locus><author authorityID="465" scan="@465" type="internal"><alias><authorityAuthor date="347-407" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Chrysostomus,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Johannes Chrysostomus,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Crisostomo, Giovanni,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Giovanni Crisostomo,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Giovanni Boccadoro,</authorityAuthor></alias></author><title scan="@1De petitione matris filiorum Zebedaei_supplied" type="supplied" value="De petitione matris filiorum Zebedaei">De petitione matris filiorum Zebedaei</title><uniformTitle authorityID="40994" scan="@40994" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="De petitione matris filiorum Zebedaei (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407)">De petitione matris filiorum Zebedaei (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="De incomprehensibili Dei natura homiliae (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407). 8, De petitione matris filiorum Zebedaei">De incomprehensibili Dei natura homiliae (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407). 8, De petitione matris filiorum Zebedaei</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Contra Anomoeos homilia 8 (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407)">Contra Anomoeos homilia 8 (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 132v λόγ. Λ´.. τοῦ.. ΙΩΑΝΝΟΥ.. Χρυσοστόμ... εἰς τὴν ῥῆσιν εὐαγγελιστικὴν - Τὸ δὲ καθίσαι ἐκ δεξιῶν μου..</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">12/12/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="12/12/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184282" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850140v-151r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>140v-151r</locus><author authorityID="22827" scan="@22827" type="internal"><alias><authorityAuthor date="c. 660-c. 720" rif="aut" title="s., arciv. di Gortyna," type="person">Andreas Cretensis,</authorityAuthor></alias></author><title scan="@1Homilia in Lazarum quatriduanum_supplied" type="supplied" value="Homilia in Lazarum quatriduanum">Homilia in Lazarum quatriduanum</title><uniformTitle authorityID="40788" scan="@40788" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In Lazarum quatriduanum (Andreas Cretensis, s., arciv. di Gortyna, c. 660-c. 720)">In Lazarum quatriduanum (Andreas Cretensis, s., arciv. di Gortyna, c. 660-c. 720)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Homiliae (Andreas Cretensis, s., arciv. di Gortyna, c. 660-c. 720). 8, In Lazarum quatriduanum">Homiliae (Andreas Cretensis, s., arciv. di Gortyna, c. 660-c. 720). 8, In Lazarum quatriduanum</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 140v λόγ. ΛΑ´.. τοῦ ΑΝΔΡΕΟΥ.. ἐπισκ. Κρήτης εἰς τὸν.. Λάζαρον.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184283" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850151r-153v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>151r-153v</locus><author authorityID="33269" scan="@33269" type="internal"><alias><authorityAuthor date="m. 395" rif="aut" title="s., vesc. di Iconium," type="person">Amphilochius,</authorityAuthor><authorityAuthor date="m. 395" rif="see" title="s., vesc. di Iconium," type="person">Amphilochius Iconiensis,</authorityAuthor></alias></author><title scan="@1In Lazarum_supplied" type="supplied" value="In Lazarum">In Lazarum</title><uniformTitle authorityID="40789" scan="@40789" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Oratio in Lazarum quadriduanum (Amphilochius, s., vesc. di Iconium, m. 395)">Oratio in Lazarum quadriduanum (Amphilochius, s., vesc. di Iconium, m. 395)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Orationes. 3, Oratio in Lazarum quadriduanum">Orationes. 3, Oratio in Lazarum quadriduanum</authorityTitleSeries><authorityTitleSeries rif="see_also" type="uniform" value="Homilia in Lazarum quadriduanum (Leontius Constantinopolitanus, sec. VII. Opere spurie e dubbie)">Homilia in Lazarum quadriduanum (Leontius Constantinopolitanus, sec. VII. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 151 λόγ. ΛΒ´.. ΑΜΦΙΛΟΧΙΟΥ ἐπισκ. Εἰκονίου (sic).. εἰς τὸν.. Λάζαρον.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="08/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184284" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850153v-157r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>153v-157r</locus><author authorityID="465" scan="@465" type="internal"><alias><authorityAuthor date="347-407" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Chrysostomus,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Johannes Chrysostomus,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Crisostomo, Giovanni,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Giovanni Crisostomo,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Giovanni Boccadoro,</authorityAuthor></alias></author><title scan="@1In quatriduanum Lazarum_supplied" type="supplied" value="In quatriduanum Lazarum">In quatriduanum Lazarum</title><uniformTitle authorityID="40790" scan="@40790" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In quatriduanum Lazarum (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407)">In quatriduanum Lazarum (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="De incomprehensibili Dei natura homiliae (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407). 9, In quatriduanum Lazarum">De incomprehensibili Dei natura homiliae (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407). 9, In quatriduanum Lazarum</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Contra Anomoeos homilia 9 (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407)">Contra Anomoeos homilia 9 (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184285" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850162v-174r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>162v-174r</locus><author authorityID="22827" scan="@22827" type="internal"><alias><authorityAuthor date="c. 660-c. 720" rif="aut" title="s., arciv. di Gortyna," type="person">Andreas Cretensis,</authorityAuthor></alias></author><title scan="@1In ramos palmarum_supplied" type="supplied" value="In ramos palmarum">In ramos palmarum</title><uniformTitle authorityID="40792" scan="@40792" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In ramos palmarum (Andreas Cretensis, s., arciv. di Gortyna, c. 660-c. 720)">In ramos palmarum (Andreas Cretensis, s., arciv. di Gortyna, c. 660-c. 720)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Homiliae (Andreas Cretensis, s., arciv. di Gortyna, c. 660-c. 720). 9, In ramos palmarum">Homiliae (Andreas Cretensis, s., arciv. di Gortyna, c. 660-c. 720). 9, In ramos palmarum</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 162v λόγ. ΛΕ´.. ΑΝΔΡΕΟΥ.. ἐπισκ. Κρήτης.. εἰς τὰ Βαΐα.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184286" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850174r-176r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>174r-176r</locus><author authorityID="3282" scan="@3282" type="internal"><alias><authorityAuthor date="m. c. 446" rif="aut" title="s., arciv. di Costantinopoli," type="person">Proclus,</authorityAuthor><authorityAuthor date="m. c. 446" rif="see" title="s., arciv. di Costantinopoli," type="person">Proclus Constantinopolitanus,</authorityAuthor></alias></author><title scan="@1In ramos Palmarum_supplied" type="supplied" value="In ramos Palmarum">In ramos Palmarum</title><uniformTitle authorityID="40793" scan="@40793" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In ramos Palmarum (Proclus, s., arciv. di Costantinopoli, m. c. 446)">In ramos Palmarum (Proclus, s., arciv. di Costantinopoli, m. c. 446)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Homiliae (Proclus, s., arciv. di Costantinopoli, m. c. 446). 9, In ramos Palmarum">Homiliae (Proclus, s., arciv. di Costantinopoli, m. c. 446). 9, In ramos Palmarum</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 174 λόγ. ΛϚ´.. ΠΡΟΚΛΟΥ.. Κπ̅ολ.. εἰς τὰ Βαΐα.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184287" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850176r-178v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>176r-178v</locus><author authorityID="4473" scan="@4473" type="internal"><alias><authorityAuthor date="347-407." formal="Opere spurie e dubbie" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor></alias></author><title scan="@1In illud: Collegerunt Judaei_supplied" type="supplied" value="In illud: Collegerunt Judaei">In illud: Collegerunt Judaei</title><uniformTitle authorityID="40797" scan="@40797" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In illud: Collegerunt Judaei (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)">In illud: Collegerunt Judaei (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, pp. 52-53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="11/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184288" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850207r-210r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>207r-210r</locus><author authorityID="138" scan="@138" type="internal"><alias><authorityAuthor date="303-373" rif="aut" title="s.," type="person">Ephraem Syrus,</authorityAuthor><authorityAuthor date="303-373" rif="see" title="s.," type="person">Ephraem Graecus,</authorityAuthor></alias></author><title scan="@1De passione Salvatoris_supplied" type="supplied" value="De passione Salvatoris">De passione Salvatoris</title><uniformTitle authorityID="40796" scan="@40796" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Sermo de passione Salvatoris (Ephraem Syrus, s., 303-373)">Sermo de passione Salvatoris (Ephraem Syrus, s., 303-373)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 207 λόγ. ΜΔ´.. τοῦ.. ΕΦΡΑΙΜ εἰς τὸ.. πάθος τοῦ.. Χριστοῦ..</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="29/12/2015">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184289" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850210r-214v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>210r-214v</locus><author authorityID="4473" scan="@4473" type="internal"><alias><authorityAuthor date="347-407." formal="Opere spurie e dubbie" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor></alias></author><title scan="@1In sancta et magna parasceve_supplied" type="supplied" value="In sancta et magna parasceve">In sancta et magna parasceve</title><uniformTitle authorityID="40815" scan="@40815" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In sancta et magna Parasceve (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)">In sancta et magna Parasceve (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)</authorityTitleSeries><authorityTitleSeries rif="see_also" type="uniform" value="Sermo in sanctum Parasceven et in Crucem (Iohannes Damascenus, s., 670-756)">Sermo in sanctum Parasceven et in Crucem (Iohannes Damascenus, s., 670-756)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="29/12/2015">D.Lionetti</persName><persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="184290" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850220v-230r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>220v-230r</locus><author authorityID="76" scan="@76" type="internal"><alias><authorityAuthor date="c. 315-403." formal="Opere spurie e dubbie" rif="aut" title="s., vesc. di Costanza in Cipro," type="person">Epiphanius,</authorityAuthor></alias></author><title scan="@1Homilia in divini corporis sepulturam_supplied" type="supplied" value="Homilia in divini corporis sepulturam">Homilia in divini corporis sepulturam</title><uniformTitle authorityID="40819" scan="@40819" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Homilia in divini corporis sepulturam (Epiphanius, s., vesc. di Costanza in Cipro, c. 315-403. Opere spurie e dubbie)">Homilia in divini corporis sepulturam (Epiphanius, s., vesc. di Costanza in Cipro, c. 315-403. Opere spurie e dubbie)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Homiliae (Epiphanius, s., vesc. di Costanza in Cipro, c. 315-403. Opere spurie e dubbie). 2, In divini corporis sepulturam">Homiliae (Epiphanius, s., vesc. di Costanza in Cipro, c. 315-403. Opere spurie e dubbie). 2, In divini corporis sepulturam</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 220v λόγ. ΜΖ´ .. - ΕΠΙΦΑΝΙΟΥ... ἐπισκ. Κύπρου.. εἰς τὴν θεόσωμον ταφὴν τοῦ.. Χριστοῦ..</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="29/12/2015"></date>
+				<persName>D.Lionetti</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/01/2016">D.Lionetti</persName><persName n="15/02/2016">Linking System: R.Mancusi</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="206593" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850046r-60v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>46r-60v</locus><author authorityID="28332" scan="@28332" type="internal"><alias><authorityAuthor date="c. 330-390" rif="aut" title="s.," type="person">Gregorius Nazianzenus,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorius Constantinopolitanus,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorio di Nazianzo,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorio il Teologo,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorio Nazianzeno,</authorityAuthor><authorityAuthor date="c. 330-390" rif="see" title="s.," type="person">Gregorius Theologus,</authorityAuthor></alias></author><title scan="@1In sanctum baptisma_supplied" type="supplied" value="In sanctum baptisma">In sanctum baptisma</title><uniformTitle authorityID="37086" scan="@37086" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In s. Baptisma (Gregorius Nazianzenus, s., c. 330-390)">In s. Baptisma (Gregorius Nazianzenus, s., c. 330-390)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Orationes (Gregorius Nazianzenus, s., c. 330-390). 40, In s. Baptisma">Orationes (Gregorius Nazianzenus, s., c. 330-390). 40, In s. Baptisma</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang><note anchored="yes">Fol. 38 ..ΓΡΗΓΟΡΙΟΥ.. Ναζιανζοῦ.. εἰς τὰ Φῶτα - λόγ. ΙΑ´. Fol. 46 Τοῦ αὐτοῦ εἰς τὸ Βάπτισμα λόγ. ΙΒ´.Post folium 54 aliquid deest. Deinde sequitur pars sermonis XVI.</note></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="25/11/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">13/12/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="25/11/2016">A.Berloco</persName><persName n="28/11/2016">A.Berloco</persName><persName n="13/12/2016">A.Berloco</persName><persName n="13/12/2016">A.Berloco</persName>
+					<persName n="13/12/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="206604" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850114r-117v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>114r-117v</locus><author authorityID="4473" scan="@4473" type="internal"><alias><authorityAuthor date="347-407." formal="Opere spurie e dubbie" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor></alias></author><title scan="@1In Annuntiationem ss. Deiparae_supplied" type="supplied" value="In Annuntiationem ss. Deiparae">In Annuntiationem ss. Deiparae</title><uniformTitle authorityID="40779" scan="@40779" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In Annuntiationem ss. Deiparae (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)">In Annuntiationem ss. Deiparae (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="28/11/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="206605" xmlns:ino="http://namespaces.softwareag.com/tamino/response2">
+	<teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850105r-113v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>105r-113v</locus><author authorityID="3282" scan="@3282" type="internal"><alias><authorityAuthor date="m. c. 446" rif="aut" title="s., arciv. di Costantinopoli," type="person">Proclus,</authorityAuthor><authorityAuthor date="m. c. 446" rif="see" title="s., arciv. di Costantinopoli," type="person">Proclus Constantinopolitanus,</authorityAuthor></alias></author><title scan="@1Laudatio de genitricis Mariae_supplied" type="supplied" value="Laudatio de genitricis Mariae">Laudatio de genitricis Mariae</title><uniformTitle authorityID="40780" scan="@40780" type="uniform"><alias><authorityTitleSeries rif="see" type="uniform" value="Homiliae (Proclus, s., arciv. di Costantinopoli, m. c. 446). 6, Laudatio s. Dei genitricis Mariae">Homiliae (Proclus, s., arciv. di Costantinopoli, m. c. 446). 6, Laudatio s. Dei genitricis Mariae</authorityTitleSeries><authorityTitleSeries rif="aut" type="uniform" value="Laudatio s. dei genitricis Mariae (Proclus, s., arciv. di Costantinopoli, m. c. 446)">Laudatio s. dei genitricis Mariae (Proclus, s., arciv. di Costantinopoli, m. c. 446)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="28/11/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date"></date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						
+					</resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader>
+	<text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text>
+</TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="206630" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850157r-162v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>157r-162v</locus><author authorityID="4473" scan="@4473" type="internal"><alias><authorityAuthor date="347-407." formal="Opere spurie e dubbie" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor></alias></author><title scan="@1In ramos palmarum_supplied" type="supplied" value="In ramos palmarum">In ramos palmarum</title><uniformTitle authorityID="40791" scan="@40791" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In ramos palmarum (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)">In ramos palmarum (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 52.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="28/11/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="206641" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850178v-182v" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>178v-182v</locus><author authorityID="4473" scan="@4473" type="internal"><alias><authorityAuthor date="347-407." formal="Opere spurie e dubbie" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor></alias></author><title scan="@1In Illud: Exeuntes Pharisaei_supplied" type="supplied" value="In Illud: Exeuntes Pharisaei">In Illud: Exeuntes Pharisaei</title><uniformTitle authorityID="40798" scan="@40798" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In illud: Exeuntes Pharisaei (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)">In illud: Exeuntes Pharisaei (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, pp. 52-53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="28/11/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="206643" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850182v-184r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>182v-184r</locus><author authorityID="4473" scan="@4473" type="internal"><alias><authorityAuthor date="347-407." formal="Opere spurie e dubbie" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor></alias></author><title scan="@1In meretricem et in pharisaeum_supplied" type="supplied" value="In meretricem et in pharisaeum">In meretricem et in pharisaeum</title><uniformTitle authorityID="33302" scan="@33302" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In meretricem et in Pharisaeum (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)">In meretricem et in Pharisaeum (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, pp. 52-53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="28/11/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="28/11/2016">A.Berloco</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="206650" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850184r-188r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>184r-188r</locus><author authorityID="33213" scan="@33213" type="internal"><alias><authorityAuthor date="m. 408/431" rif="aut" title="s.," type="person">Severianus Gabalensis,</authorityAuthor><authorityAuthor date="m. 408/431" rif="see" title="s.," type="person">Severianus Gabalitanus,</authorityAuthor><authorityAuthor date="m. 408/431" rif="see" title="s., vesc. di Gabala," type="person">Severiano,</authorityAuthor></alias></author><title scan="@1In meretricem et Pharisaeum_supplied" type="supplied" value="In meretricem et Pharisaeum">In meretricem et Pharisaeum</title><uniformTitle authorityID="40809" scan="@40809" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In meretricem et Pharisaeum (Severianus Gabalensis, s., f. 400-408)">In meretricem et Pharisaeum (Severianus Gabalensis, s., f. 400-408)</authorityTitleSeries><authorityTitleSeries rif="see_also" type="uniform" value="In meretricem et in Pharisaeum (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)">In meretricem et in Pharisaeum (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, pp. 52-53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="28/11/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">28/11/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="28/11/2016">A.Berloco</persName><persName n="28/11/2016">A.Berloco</persName>
+					<persName n="28/11/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="206664" xmlns:ino="http://namespaces.softwareag.com/tamino/response2">
+	<teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850188r-196r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>188r-196r</locus><author authorityID="465" scan="@465" type="internal"><alias><authorityAuthor date="347-407" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Chrysostomus,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Johannes Chrysostomus,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Crisostomo, Giovanni,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Giovanni Crisostomo,</authorityAuthor><authorityAuthor date="347-407" rif="see" title="s., patriarca di Costantinopoli," type="person">Giovanni Boccadoro,</authorityAuthor></alias></author><title scan="@1De proditione Judae homilae I et II_supplied" type="supplied" value="De proditione Judae homilae I et II">De proditione Judae homilae I et II</title><uniformTitle authorityID="40804" scan="@40804" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="De proditione Judae homiliae (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407)">De proditione Judae homiliae (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, pp. 52-53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="28/11/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date"></date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						
+					</resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader>
+	<text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text>
+</TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="206665" xmlns:ino="http://namespaces.softwareag.com/tamino/response2">
+	<teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850196r-199r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>196r-199r</locus><author authorityID="33213" scan="@33213" type="internal"><alias><authorityAuthor date="m. 408/431" rif="aut" title="s.," type="person">Severianus Gabalensis,</authorityAuthor><authorityAuthor date="m. 408/431" rif="see" title="s.," type="person">Severianus Gabalitanus,</authorityAuthor><authorityAuthor date="m. 408/431" rif="see" title="s., vesc. di Gabala," type="person">Severiano,</authorityAuthor></alias></author><title scan="@1Homilia de lotione pedum_supplied" type="supplied" value="Homilia de lotione pedum">Homilia de lotione pedum</title><uniformTitle authorityID="40812" scan="@40812" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Homilia de lotione pedum (Severianus Gabalensis, s., f. 400-408)">Homilia de lotione pedum (Severianus Gabalensis, s., f. 400-408)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, pp. 52-53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="28/11/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date"></date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						
+					</resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader>
+	<text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text>
+</TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="206666" xmlns:ino="http://namespaces.softwareag.com/tamino/response2">
+	<teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850199r-207r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>199r-207r</locus><author authorityID="4473" scan="@4473" type="internal"><alias><authorityAuthor date="347-407." formal="Opere spurie e dubbie" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor></alias></author><title scan="@1In Illud: Pater si possibile est_supplied" type="supplied" value="In Illud: Pater si possibile est">In Illud: Pater si possibile est</title><uniformTitle authorityID="40813" scan="@40813" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In illud: Pater si possibile est (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)">In illud: Pater si possibile est (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, pp. 52-53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="28/11/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date"></date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						
+					</resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader>
+	<text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text>
+</TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="206671" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Ott.gr." rend="Ott.gr.000850214v-220r" scan="@5Ott.gr.85_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Ott.gr.85">Ott.gr.85</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>214v-220r</locus><author authorityID="4473" scan="@4473" type="internal"><alias><authorityAuthor date="347-407." formal="Opere spurie e dubbie" rif="aut" title="s., patriarca di Costantinopoli," type="person">Iohannes Chrysostomus,</authorityAuthor></alias></author><title scan="@1In vivificam sepulturam et triduanam resurrectionem Christi_supplied" type="supplied" value="In vivificam sepulturam et triduanam resurrectionem Christi">In vivificam sepulturam et triduanam resurrectionem Christi</title><uniformTitle authorityID="41000" scan="@41000" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="In vivificam sepulturam et triduanam resurrectionem Christi (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)">In vivificam sepulturam et triduanam resurrectionem Christi (Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie)</authorityTitleSeries></alias></uniformTitle><textLang n="Greco." rend="grc">Greco.</textLang></msItem></msContents><additional><adminInfo><recordHist><source><p>E. Feron, F. Battaglini, Codices manuscripti graeci Ottoboniani Bibliothecae Vaticanae descripti, Romae 1893, p. 53.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="28/11/2016"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">13/12/2016</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="12/12/2016">A.Berloco</persName>
+					<persName n="13/12/2016">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+</ino:request>

--- a/spec/fixtures/tei/Vat.lat.3195.xml
+++ b/spec/fixtures/tei/Vat.lat.3195.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ino:request xmlns:ino="http://namespaces.softwareag.com/tamino/response2">
+<ino:object>
+<TEI.2 inoid="210273" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="y"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Vat.lat." rend="Vat.lat.031950000" scan="@5Vat.lat.3195_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Vat.lat.3195">Vat.lat.3195</idno>
+					</msIdentifier><msPart><head><scriptTerm>&lt;semigotica&gt;</scriptTerm></head><msContents><msItem><textLang n="Latino." rend="ita">Italiano.</textLang><name authorityID="42406" role="scribe" scan="@42406"><alias><authorityAuthor date="n. c. 1346-m. c. 1417" rif="aut" type="person">Malpaghini, Giovanni,</authorityAuthor></alias></name><name authorityID="631" role="internal" scan="@631"><alias><authorityAuthor date="1304-1374" rif="aut" type="person">Petrarca, Francesco,</authorityAuthor><authorityAuthor date="1304-1374" rif="see" type="person">Petrarcha, Francesco,</authorityAuthor><authorityAuthor date="1304-1374" rif="see" type="person">Petracco, Francesco,</authorityAuthor><authorityAuthor date="1304-1374" rif="see" type="person">P. F.,</authorityAuthor></alias></name><name authorityID="7350" role="owner" scan="@7350"><alias><authorityAuthor date="1470-1547" rif="aut" title="card.," type="person">Bembo, Pietro,</authorityAuthor></alias></name><name authorityID="32677" role="owner" scan="@32677"><alias><authorityAuthor date="m. 1595" rif="aut" type="person">Bembo, Torquato,</authorityAuthor></alias></name><name authorityID="3585" role="owner" scan="@3585"><alias><authorityAuthor date="1529-1600" rif="aut" type="person">Orsini, Fulvio,</authorityAuthor><authorityAuthor date="1529-1600" rif="see" type="person">Ursinus Fulvius,</authorityAuthor></alias></name><origPlace><country>Italia</country><region>Italia settentrionale</region></origPlace><origDate n="1366-1374">sec. XIV ex</origDate></msItem></msContents><physDesc><support><p>membr.</p></support><dimensions><height>270</height><width>202</width></dimensions><extent>ff. I, 1a e 1b, 72, I&#39; (ff. I e I&#39; guardie moderne non numerate)</extent><msWriting><p>Due mani: la prima &lt;(G. Malpaghini)&gt; ai ff. 1r-38v, 53r-62r, la seconda &lt;(F. Petrarca)&gt; ai ff. 38v-49r, 62r-72v; di mano del sec. XV la tavola dei capoversi ai ff. 1av-1bv. Rare note marginali dellaa seconda mano e di altre mani posteriori (sec. XV-XVI).</p></msWriting></physDesc><additional><adminInfo><recordHist><source><p>IAM41.4 -Rerum vulgarium fragmenta: codice Vat.lat.3195. Commentario all&#39;edizione in facsimile, G. Belloni (cur.), Padova 2006.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="07/02/2017"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">05/10/2017</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						<persName n="07/02/2017">A.Berloco</persName>
+					<persName n="05/10/2017">F.Borzumato</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+<ino:object>
+<TEI.2 inoid="210275" xmlns:ino="http://namespaces.softwareag.com/tamino/response2"><teiHeader status="new">
+		<fileDesc>
+			<titleStmt>
+				
+			</titleStmt>
+			<publicationStmt>
+				<p></p>
+			</publicationStmt>
+			<sourceDesc default="NO">
+				<msDescription n="n"><msIdentifier type="primary">
+						<repository>Biblioteca Apostolica Vaticana</repository>
+						<idno TEIform="0" n="Vat.lat." rend="Vat.lat.031950001r-49r. 53r-72v" scan="@5Vat.lat.3195_ms" type="ms" uriSYS="http://digi.vatlib.it/view/MSS_Vat.lat.3195">Vat.lat.3195</idno>
+					</msIdentifier><msPart><msContents><msItem><locus>1r-49r. 53r-72v</locus><author authorityID="631" scan="@631"><alias><authorityAuthor date="1304-1374" rif="aut" type="person">Petrarca, Francesco,</authorityAuthor><authorityAuthor date="1304-1374" rif="see" type="person">Petrarcha, Francesco,</authorityAuthor><authorityAuthor date="1304-1374" rif="see" type="person">Petracco, Francesco,</authorityAuthor><authorityAuthor date="1304-1374" rif="see" type="person">P. F.,</authorityAuthor></alias></author><title scan="@1Rerum vulgarium fragmenta_title" type="title" value="Rerum vulgarium fragmenta">Rerum vulgarium fragmenta</title><uniformTitle authorityID="41081" scan="@41081" type="uniform"><alias><authorityTitleSeries rif="aut" type="uniform" value="Rerum vulgarium fragmenta (Petrarca, Francesco, 1304-1374)">Rerum vulgarium fragmenta (Petrarca, Francesco, 1304-1374)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Canzoniere (Petrarca, Francesco, 1304-1374)">Canzoniere (Petrarca, Francesco, 1304-1374)</authorityTitleSeries><authorityTitleSeries rif="see" type="uniform" value="Rime (Petrarca, Francesco, 1304-1374)">Rime (Petrarca, Francesco, 1304-1374)</authorityTitleSeries></alias></uniformTitle><textLang n="Latino." rend="ita">Italiano.</textLang><note anchored="yes">Precede la tavola dei capoversi (ff. 1av-1bv).</note><name authorityID="42406" role="scribe" scan="@42406"><alias><authorityAuthor date="n. c. 1346-m. c. 1417" rif="aut" type="person">Malpaghini, Giovanni,</authorityAuthor></alias></name></msItem></msContents><additional><adminInfo><recordHist><source><p>Rerum vulgarium fragmenta: codice Vat.lat.3195. Commentario all&#39;edizione in facsimile, G. Belloni (cur.), Padova 2006.</p></source></recordHist></adminInfo></additional></msPart></msDescription>
+			</sourceDesc>
+		</fileDesc>
+		<profileDesc>
+			<creation>
+				<date TEIform="date" value="07/02/2017"></date>
+				<persName>A.Berloco</persName>
+				<orig>console</orig>
+			</creation>
+		</profileDesc>
+		<revisionDesc>
+			<change>
+				<date TEIform="date">26/04/2017</date>
+				<respStmt>
+					<resp>
+						<name type="org">BAV</name>
+						
+					<persName n="26/04/2017">A.Berloco</persName></resp>
+				</respStmt>
+				<item id="Vero"></item>
+			</change>
+		</revisionDesc>
+	</teiHeader><text>
+		<body>
+			<bibl default="NO"></bibl>
+		</body>
+	</text></TEI.2>
+</ino:object>
+</ino:request>


### PR DESCRIPTION
Fixes #241 

![specialnames](https://user-images.githubusercontent.com/1656824/44233717-7f9da800-a159-11e8-8f6e-74d380399bce.gif)

With input and discussion from @ggeisler , this PR adds a special logic to creating "name" type fields for indexing. This happens for the "facet" fields (`*_ssim`) and also the "manuscript show" fields (`ms_*_tesim`). I've left this off of the parts fields, but that could easily be added on.

Also adds the line separator for show page on these particular fields.