### PR TITLE
do not recreate the custom field on seed if it already exists

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,5 +14,5 @@ data['pathways'].each do |pathway|
   iiif_urls = pathway['manuscripts'].map { |shelfmark| Settings.vatican_iiif_resource.iiif_template_url.gsub('{shelfmark}', shelfmark) }
   VaticanIiifResource.instance(exhibit).update(iiif_url_list: iiif_urls.join("\n"))
 
-  exhibit.custom_fields.create(field: Settings.curatorial_narrative.field)
+  exhibit.custom_fields.find_or_create_by(field: Settings.curatorial_narrative.field)
 end


### PR DESCRIPTION
Fixes #270 

Final part of #270, #275 updated Spotlight which added the input -> text area change.