### PR TITLE
Pin uglifier to v4.1.18 as 4.1.19 broke Mirador show page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+gem 'uglifier', '>= 1.3.0', '<= 4.1.18'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -561,7 +561,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.1.0)
-    uglifier (4.1.19)
+    uglifier (4.1.18)
       execjs (>= 0.3.0, < 3)
     underscore-rails (1.8.3)
     unf (0.1.4)
@@ -646,9 +646,9 @@ DEPENDENCIES
   traject_plus
   turbolinks (~> 5)
   tzinfo-data
-  uglifier (>= 1.3.0)
+  uglifier (>= 1.3.0, <= 4.1.18)
   web-console (>= 3.3.0)
   webmock
 
 BUNDLED WITH
-   1.16.3
+   1.16.4


### PR DESCRIPTION
There is an update in 4.1.19 that breaks the Mirador show page /shrug