### PR TITLE
reduce max-height to support exaggerated vertical annotations

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -99,7 +99,7 @@ body {
 }
 
 .document-thumbnail img {
-  max-height: 200px;
+  max-height: 100px;
   max-width: 100%;
 }
 


### PR DESCRIPTION
Fixes an issue where vertically exaggerated annos were overlapping in results view.

<img width="525" alt="screen shot 2018-09-21 at 1 12 31 pm" src="https://user-images.githubusercontent.com/1656824/45878089-2c45f780-bda0-11e8-9aad-46af3cffa8cf.png">
<img width="462" alt="screen shot 2018-09-21 at 1 12 20 pm" src="https://user-images.githubusercontent.com/1656824/45878091-2c45f780-bda0-11e8-81ea-503d81b5889a.png">
