### PR TITLE
Ensure list view rows are tall enough even with minimal metadata

### DIFF
--- a/app/assets/stylesheets/modules/blacklight_overrides.scss
+++ b/app/assets/stylesheets/modules/blacklight_overrides.scss
@@ -99,7 +99,7 @@ body {
 }
 
 .document-thumbnail img {
-  max-height: 100px;
+  max-height: 110px;
   max-width: 100%;
 }
 
@@ -120,7 +120,7 @@ body {
   &.documents-list {
     .document {
       box-sizing: content-box;
-      min-height: 100px;
+      min-height: 140px;
       padding-bottom: $padding-large-vertical;
       padding-top: $padding-large-vertical;
     }


### PR DESCRIPTION
Our previous update that was intended to prevent thumbnail images in the results list view from overlapping (#300) worked for most cases but not all (I think we didn't notice because we were focused on fixing the issue for annotation thumbnails and didn't know it also occurred occasionally for manuscript thumbnails), for example:

<img width="557" alt="row-height-before" src="https://user-images.githubusercontent.com/101482/47322222-10867900-d60c-11e8-87f2-0941edf46b4b.png">

Basically, when a given result item has fewer metadata fields to display than expected the height of the item's row is less than the height of the thumbnail image and we still can see the overlap.

This PR increases the min-height of the list view item rows to ensure they are always tall enough to fit the entire thumbnail image within. I also increased the height of the thumbnail images slightly just to make them a bit bigger, knowing that the other change will still ensure they fit within the item row height. Here's the after:

<img width="538" alt="row-height-after" src="https://user-images.githubusercontent.com/101482/47322377-8be82a80-d60c-11e8-84b4-c9c6c5784116.png">


