### PR TITLE
Fix issues with annotations

### DIFF
--- a/app/jobs/index_annotation_job.rb
+++ b/app/jobs/index_annotation_job.rb
@@ -23,8 +23,6 @@ class IndexAnnotationJob < ApplicationJob
   end
 
   def manifest_uri(annotation)
-    return unless JSON.parse(annotation.data)['on']
-
-    JSON.parse(annotation.data)['on'].first['within']['@id']
+    AnnotationCompatibility.new(JSON.parse(annotation.data)).manifest_uri
   end
 end

--- a/app/models/annotation_compatibility.rb
+++ b/app/models/annotation_compatibility.rb
@@ -1,0 +1,36 @@
+##
+# Handles the ability to determine an Annotation's manifest uri from
+# multiple formats
+class AnnotationCompatibility
+  attr_reader :data
+
+  # @param [Hash] data
+  def initialize(data)
+    @data = data
+  end
+
+  def manifest_uri
+    return unless data['on']
+
+    case data['on']
+    when String
+      data['on'].gsub(/canvas.*/, 'manifest.json')
+    when Array
+      data['on'].first['within']['@id']
+    end
+  end
+
+  def selector
+    return unless data['on']
+
+    case data['on']
+    when String
+      {
+        'value' => data['on'],
+        '@type' => 'oa:FragmentSelector'
+      }
+    when Array
+      data['on'].first['selector']['default']
+    end
+  end
+end

--- a/lib/tasks/annotations.rake
+++ b/lib/tasks/annotations.rake
@@ -63,7 +63,8 @@ namespace :annotations do
           end
         end
 
-        annotation.data = data.to_json
+        # We don't want to double encode JSON data here
+        annotation.data = data.is_a?(Hash) ? data.to_json : data
         annotation.save!
       end
     end

--- a/lib/traject/annotation_config.rb
+++ b/lib/traject/annotation_config.rb
@@ -16,7 +16,7 @@ each_record do |record, context|
   end
   context.clipboard[:canvas] = ::JSON.parse(canvas_body)
 
-  manifest_url = context.clipboard[:annotation]['on'].first['within']['@id']
+  manifest_url = AnnotationCompatibility.new(context.clipboard[:annotation]).manifest_uri
   manifest_body = Rails.cache.fetch(manifest_url) do
     Faraday.get(manifest_url).body
   end
@@ -123,7 +123,7 @@ end)
 
 to_field 'thumbnail_url_ssm', (accumulate do |_resource, context|
   image = context.clipboard[:canvas]['images'].first['resource']['service']['@id']
-  selector = context.clipboard[:annotation]['on'].first['selector']['default']
+  selector = AnnotationCompatibility.new(context.clipboard[:annotation]).selector
   region = selector['value'].sub('xywh=', '') if selector['@type'] == 'oa:FragmentSelector'
   region ||= 'full'
   "#{image}/#{region}/100,/0/default.jpg"

--- a/spec/models/annotation_compatibility_spec.rb
+++ b/spec/models/annotation_compatibility_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe AnnotationCompatibility do
+  let(:simple_fragment) do
+    described_class.new(
+      'on' => 'http://www.example.com/shelfmark/canvas/01#xywh=0,0,100,100'
+    )
+  end
+
+  let(:complex_fragment) do
+    described_class.new(
+      'on' => [
+        'selector' => {
+          'default' => {
+            '@type' => 'oa:FragmentSelector',
+            'value' => 'xywh=0,0,100,100'
+          }
+        },
+        'within' => {
+          '@id' => 'http://www.example.com/shelfmark/manifest.json',
+          '@type' => 'sc:Manifest'
+        }
+      ]
+    )
+  end
+
+  describe '#manifest_uri' do
+    it 'works with a simple format' do
+      expect(simple_fragment.manifest_uri).to eq 'http://www.example.com/shelfmark/manifest.json'
+    end
+    it 'works with a complex format' do
+      expect(complex_fragment.manifest_uri).to eq 'http://www.example.com/shelfmark/manifest.json'
+    end
+  end
+
+  describe '#selector' do
+    it 'works with a simple format' do
+      expect(simple_fragment.selector).to eq(
+        '@type' => 'oa:FragmentSelector',
+        'value' => 'http://www.example.com/shelfmark/canvas/01#xywh=0,0,100,100'
+      )
+    end
+    it 'works with a complex format' do
+      expect(complex_fragment.selector).to eq(
+        '@type' => 'oa:FragmentSelector',
+        'value' => 'xywh=0,0,100,100'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Fixes #263 

The intent of this is to fix issues with annotations not indexing properly. This seemed to stem from annotations that were loaded via the API (not created directly by current version of Mirador) that did not adhere to the exact same format. 

This has been a recurring issue unfortunately and I'm hoping this shim helps resolve some of the issues seen.