### PR TITLE
Allow additional html in curatorial narrative

### DIFF
--- a/app/helpers/spotlight_helper.rb
+++ b/app/helpers/spotlight_helper.rb
@@ -6,7 +6,7 @@ module SpotlightHelper
 
   def render_minimally_styled_narrative_field(value:, **_args)
     safe_join(Array(value).map do |v|
-      sanitize v, tags: %w[strong em p a], attributes: %w[href]
+      sanitize v, tags: %w[strong em p a i b br], attributes: %w[href target]
     end, '')
   end
 

--- a/spec/helpers/spotlight_helper_spec.rb
+++ b/spec/helpers/spotlight_helper_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe SpotlightHelper, type: :helper do
     let(:value) do
       <<-EOHTML
       <p><span style="font-size: 12.0pt; line-height: 115%; font-family: 'Calibri',sans-serif; mso-ascii-theme-font: minor-latin; mso-fareast-font-family: Calibri; mso-fareast-theme-font: minor-latin; mso-hansi-theme-font: minor-latin; mso-bidi-theme-font: minor-latin; mso-ansi-language: IT; mso-fareast-language: EN-US; mso-bidi-language: AR-SA;">La <em>r</em> e la <em>s</em> hanno forme molto simili con l&rsquo;unica differenza che, mentre la <em>r</em> ripiega bruscamente in forma angolosa, la <em>s</em> ha una forma pi&ugrave; tondeggiante.</span></p>
+      <p><b>Coffee</b> <i>crema</i> breve, <br>french press, turkish, cultivar java, whipped that qui pumpkin spice black. Rich, viennese, steamed as carajillo roast café au lait mazagran caffeine. Single origin so, fair trade eu, acerbic shop siphon acerbic robust brewed con panna.</p>
       EOHTML
     end
 


### PR DESCRIPTION
Closes #317 

This PR allows the following tags in the curatorial narrative:
 - [x] `<i>`
 - [x] `<b>`
 - [x] `<br>`
 - [x] `target`

**Note**: GIF illustrates that the `target="_blank"` attribute is honored afterwards

## Before
![partially styled field](https://user-images.githubusercontent.com/5402927/48874130-73ebfe00-eda6-11e8-9066-7a2e47092815.png)

![before_narrative](https://user-images.githubusercontent.com/5402927/48874133-78181b80-eda6-11e8-801e-07b27e632ce3.gif)

## After
![additional html tags rendered](https://user-images.githubusercontent.com/5402927/48874129-73ebfe00-eda6-11e8-94eb-f8f064042fa8.png)

![after_narrative](https://user-images.githubusercontent.com/5402927/48874134-78181b80-eda6-11e8-9a9d-0a129fa4a3e0.gif)

## Test HTML used
```html
Here's a narrative with a wild number of html tags:
<p><strong>===Current tags:===</strong></p>
<p><strong>strong</strong></p>
<p><em>emphasis</em></p>
<p>paragraph</p>
<p><a>a link</a></p>


<p><strong>===New tags:===</strong></p>
<p><i>Italic</i></p>
<p><b>bold</b></p>
<br>a line break
<br / >a self-closing line break
<p><a href="https://writtenkitten.net/" target="_blank">link with target</a></p>
```
