### PR TITLE
Remove two of the More Info sidebar links

### DIFF
--- a/app/views/shared/_site_sidebar.html.erb
+++ b/app/views/shared/_site_sidebar.html.erb
@@ -2,12 +2,6 @@
   <h2 class="nav-heading">More information</h2>
   <ul class="nav sidenav">
     <li>
-      <%= link_to "Project background", "#" %>
-    </li>
-    <li>
-      <%= link_to "Project staff", "#" %>
-    </li>
-    <li>
       <%= link_to "Vatican library", "https://www.vaticanlibrary.va" %>
     </li>
     <li>

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Homepage', type: :feature do
   it 'has custom more information links' do
     visit '/'
-    expect(page).to have_link 'Project background'
-    expect(page).to have_link 'Project staff'
     expect(page).to have_link 'Vatican library'
     expect(page).to have_link 'DigiVatLib'
     expect(page).to have_link 'Online catalog'


### PR DESCRIPTION
Fixes #339 

Removed first two links so the More Info sidebar section now looks like this:

<img width="289" alt="thematic_pathways_of_medieval_manuscripts" src="https://user-images.githubusercontent.com/101482/49107173-4093ee00-f242-11e8-9c55-8b7d6381d125.png">
