### PR TITLE
Move curatorial narrative above manuscript parts

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -12,7 +12,7 @@ class CatalogController < ApplicationController
     config.show.oembed_field = :oembed_url_ssm
     config.show.partials.insert(1, :oembed)
     config.show.partials.insert(1, :viewer)
-    config.show.partials.insert(3, :curatorial_narrative)
+    config.show.partials.insert(4, :curatorial_narrative)
     config.show.partials << :parts
     config.show.partials << :annotations
     config.view.parts.partials = [:part_header, :part_show]


### PR DESCRIPTION
Closes #303

This PR moves the "Curatorial narrative" section from above "Manuscript information" to just above "Parts of this manuscript"

## Before
![curatorial_narrative_before](https://user-images.githubusercontent.com/5402927/49122934-6ed9f380-f26b-11e8-818f-59fbeadd8b5e.png)

## After
![curatorial_narrative_after](https://user-images.githubusercontent.com/5402927/49122935-6ed9f380-f26b-11e8-80d4-008f9318a99c.png)

