### PR TITLE
Move 'Bibliography' field to Description section

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -77,7 +77,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'ms_extent_tesim', section: :general
     config.add_show_field 'ms_content_tesim', section: :general
     config.add_show_field 'ms_overview_tesim', section: :general
-    config.add_show_field 'ms_bibl_tesim', section: :general
+    config.add_show_field 'ms_bibl_tesim'
     config.add_show_field 'ms_collation_tesim'
     config.add_show_field 'ms_layout_tesim'
     config.add_show_field 'ms_foliation_tesim'


### PR DESCRIPTION
Fixes #318 

This PR unpins the `Bibliography` field from the Manuscript information section. It now appears in the Description section and can be moved via the Curation > Metadata panel. FYI @ggeisler 

## Before
<img width="639" alt="current" src="https://user-images.githubusercontent.com/101482/48084793-e315ff80-e1b5-11e8-986a-38bd3479d3e7.png">

## After
![screen shot 2018-11-28 at 11 41 37 am](https://user-images.githubusercontent.com/5402927/49177828-0ccccd00-f303-11e8-89e4-244c83b10763.png)

Example manifest: Urb_lat_10