### PR TITLE
Force the exhibit_tags field to be in the general section.

### DIFF
--- a/app/presenters/manuscript_metadata_presenter.rb
+++ b/app/presenters/manuscript_metadata_presenter.rb
@@ -58,11 +58,19 @@ class ManuscriptMetadataPresenter
 
     def fields
       document_show_fields(document).select do |_, field|
-        field.section == type && should_render_show_field?(document, field)
+        field_is_correct_type?(field) && should_render_show_field?(document, field)
       end
     end
 
     private
+
+    # Force the ehxibit_tags field to be grouped in the :general section even though it is
+    # not configured in the controller and therefore can't be grouped via our normal means
+    def field_is_correct_type?(field)
+      return type == :general if field.key.to_sym == :exhibit_tags
+
+      field.section == type
+    end
 
     def type
       return nil if @type == :description

--- a/spec/presenters/manuscript_metadata_presenter_spec.rb
+++ b/spec/presenters/manuscript_metadata_presenter_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe ManuscriptMetadataPresenter do
   let(:document) { SolrDocument.new }
   let(:document_show_fields) { {} }
   let(:should_render_show_field) { false }
-  let(:general_field) { instance_double('Field', section: :general) }
-  let(:description_field) { instance_double('Field', section: nil) }
+  let(:general_field) { instance_double('Field', section: :general, key: 'title') }
+  let(:description_field) { instance_double('Field', section: nil, key: 'description') }
+  let(:tags_field) { instance_double('Field', section: nil, key: 'exhibit_tags') }
 
   describe 'section accessors' do
     it 'has a general, description, and admin sections' do
@@ -45,7 +46,9 @@ RSpec.describe ManuscriptMetadataPresenter do
     end
 
     describe '#fields' do
-      let(:document_show_fields) { { gen_field: general_field, desc_field: description_field } }
+      let(:document_show_fields) do
+        { gen_field: general_field, desc_field: description_field, exhibit_tags: tags_field }
+      end
 
       context 'when the description section' do
         let(:type) { :description }
@@ -55,14 +58,24 @@ RSpec.describe ManuscriptMetadataPresenter do
           expect(section.fields.values.length).to eq 1
           expect(section.fields.values.first.section).to be_nil
         end
+
+        it 'exhibit_tags are not present (even though their section is nil)' do
+          expect(section.fields.values.first.section).to be_nil
+          expect(section.fields.values.map(&:key)).not_to include 'exhibit_tags'
+        end
       end
 
       context 'when another section' do
         let(:should_render_show_field) { true }
 
         it 'is an array of fields based on the given section' do
-          expect(section.fields.values.length).to eq 1
+          expect(section.fields.values.length).to eq 2
           expect(section.fields.values.first.section).to eq :general
+        end
+
+        it 'exhibit_tags are always in the General section (even though their section is nil)' do
+          expect(section.fields.values.first.section).to eq :general
+          expect(section.fields.values.map(&:key)).to include 'exhibit_tags'
         end
       end
 


### PR DESCRIPTION
Closes #288 
Part of #329 

_Note: The screenshot below is using the default config which puts the exhibit tags at the top.  Not sure how the Vatican's pathway exhibits are actually configured._

<img width="486" alt="screen shot 2018-11-28 at 2 08 58 pm" src="https://user-images.githubusercontent.com/96776/49185593-3394fe80-f317-11e8-876c-a53a97b914d0.png">
