### PR TITLE
Add Name Display formatting to authors in Parts section

### DIFF
--- a/app/views/catalog/_part_header_default.html.erb
+++ b/app/views/catalog/_part_header_default.html.erb
@@ -2,7 +2,7 @@
 <div class="part-header">
   <h3><%= show_presenter.field_value('ms_locus_tesim') %></h3>
   <p>
-    <span class="part-author"><%= show_presenter.field_value('ms_author_tesim') %></span>
+    <span class="part-author"><%= show_presenter.field_value('ms_author_header_tesim') %></span>
     <% if document['ms_author_date_tesim'].present? %>
       <span class="part-author-date"><%= show_presenter.field_value('ms_author_date_tesim') %>.</span>
     <% end %>

--- a/lib/traject/vatican_iiif_config.rb
+++ b/lib/traject/vatican_iiif_config.rb
@@ -257,6 +257,7 @@ compose 'parts_ssm', ->(record, accumulator, _context) { accumulator.concat reco
   to_field 'ms_palimpsest_tesim', extract_xml('msPart/physDesc/palimpsest/p', nil) #	Palinsesto	Palimpsest
 
   to_field 'ms_locus_tesim', extract_xml('msPart/msContents/msItem/locus', nil) #	Locus	Locus
+  to_field 'ms_author_header_tesim', extract_xml('msPart/msContents/msItem/author/alias/authorityAuthor[@rif="aut"]', nil) #	Autore	Author for Parts section header
   to_field 'ms_author_tesim', (accumulate do |resource, *_| #	Autore	Author
     resource.xpath('msPart/msContents/msItem/author/alias/authorityAuthor[@rif="aut"]').map do |author|
       NameDisplay.new(

--- a/lib/traject/vatican_iiif_config.rb
+++ b/lib/traject/vatican_iiif_config.rb
@@ -257,8 +257,20 @@ compose 'parts_ssm', ->(record, accumulator, _context) { accumulator.concat reco
   to_field 'ms_palimpsest_tesim', extract_xml('msPart/physDesc/palimpsest/p', nil) #	Palinsesto	Palimpsest
 
   to_field 'ms_locus_tesim', extract_xml('msPart/msContents/msItem/locus', nil) #	Locus	Locus
-  to_field 'ms_author_tesim', extract_xml('msPart/msContents/msItem/author/alias/authorityAuthor[@rif="aut"]', nil) #	Autore	Author
-  to_field 'ms_other_author_tesim', extract_xml('msPart/msContents/msItem/name[@role="internal" or @role="external"]/alias/authorityAuthor[@rif="aut"]', nil) #	Altro autore	Other author
+  to_field 'ms_author_tesim', (accumulate do |resource, *_| #	Autore	Author
+    resource.xpath('msPart/msContents/msItem/author/alias/authorityAuthor[@rif="aut"]').map do |author|
+      NameDisplay.new(
+        author
+      ).display
+    end
+  end)
+  to_field 'ms_other_author_tesim', (accumulate do |resource, *_| #	Altro autore	Other author
+    resource.xpath('msPart/msContents/msItem/name[@role="internal" or @role="external"]/alias/authorityAuthor[@rif="aut"]').map do |author|
+      NameDisplay.new(
+        author
+      ).display
+    end
+  end)
   to_field 'ms_title_tesim', extract_xml('msPart/msContents/msItem/title[@type="title"]/@value', nil) #		Titolo	Title
   to_field 'ms_supplied_title_tesim', extract_xml('msPart/msContents/msItem/title[@type="supplied"]/@value', nil) #		Titolo supplito	Supplied title
   to_field 'ms_uniform_title_tesim', extract_xml('msPart/msContents/msItem/uniformTitle/alias/authorityTitleSeries[@rif="aut"]/@value', nil) #		Titolo uniforme	Uniform title
@@ -275,7 +287,13 @@ compose 'parts_ssm', ->(record, accumulator, _context) { accumulator.concat reco
   to_field 'ms_type_of_document_tesim', extract_xml('msPart/msContents/msItem/note[@anchored and not(@anchored="yes")]', nil) #	Tipologia documento	Type of document
   to_field 'ms_general_note_tesim', extract_xml('msPart/msContents/msItem/note[@anchored="yes" or not(@anchored)]', nil) #	Nota	General note
   to_field 'ms_source_note_tesim', extract_xml('msPart/msContents/msItem/note[@anchored="sourceSYS"]', nil) #		Nota di fonte	Source note
-  to_field 'ms_other_name_tesim', extract_xml('msPart/msContents/msItem/name[@role!="internal" and @role!="external" or not(@role)]/alias/authorityAuthor[@rif="aut"]', nil) #	Altro nome	Other name
+  to_field 'ms_other_name_tesim', (accumulate do |resource, *_| #	Altro nome	Other name
+    resource.xpath('msPart/msContents/msItem/name[@role!="internal" and @role!="external" or not(@role)]/alias/authorityAuthor[@rif="aut"]').map do |author|
+      NameDisplay.new(
+        author
+      ).display
+    end
+  end)
   to_field 'ms_subject_tesim', extract_xml('msPart/msContents/msItem/keywords/term/alias/authoritySubject[@rif="aut"]', nil) #	Soggetto	Subject
   to_field 'ms_language_ssim', extract_xml('msPart/msContents/msItem/textLang', nil) #	Lingua	Language
   to_field 'ms_alphabet_ssim', extract_xml('msPart/msContents/msItem/textLang/@n', nil) #	Alfabeto	Alphabet

--- a/spec/features/vatican_iiif_resource_integration_spec.rb
+++ b/spec/features/vatican_iiif_resource_integration_spec.rb
@@ -170,7 +170,8 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
       expect(data).to include hash_including(
         'ms_overview_tesim' => ['Libellus I.'],
         'ms_locus_tesim' => ['1r-38v'],
-        'ms_author_tesim' => ['Eunapius Sardianus,'],
+        'ms_author_header_tesim' => ['Eunapius Sardianus,'],
+        'ms_author_tesim' => ['Eunapius Sardianus, 354-420 [internal]'],
         'ms_supplied_title_tesim' => ['Vitae sophistarum'],
         'ms_uniform_title_tesim' => ['Vitae sophistarum (Eunapius Sardianus, 354-420)'],
         'ms_language_ssim' => ['Greco.'],


### PR DESCRIPTION
Closes #287 

This PR utilizes work from #283 to bring author info in the "Parts of this Manuscript" section in line with author info displayed in the Description section. 

TODO:
- [x] `Note that this name formatting should not be applied to the name in the part section header, just in the metadata values.` (#287)

Sample fixture: http://vatican-dev.sul.stanford.edu/overview/catalog/Vat_gr_586

## Before
![only_name_displayed](https://user-images.githubusercontent.com/5402927/49484707-d6082280-f7ec-11e8-85cc-77fe0d910d82.png)

## After
![screen shot 2018-12-17 at 4 06 35 pm](https://user-images.githubusercontent.com/5402927/50123527-f76a0500-0215-11e9-8c34-b5d0bdbb454c.png)
