### PR TITLE
add nil check for accessor for indexer

### DIFF
--- a/app/services/vatican_iiif_builder.rb
+++ b/app/services/vatican_iiif_builder.rb
@@ -31,7 +31,7 @@ class VaticanIiifBuilder < Spotlight::SolrDocumentBuilder
   ##
   # Needed because traject has a stringed key, but we need a symbol one
   def convert_id(doc)
-    doc[:id] = doc['id'].try(:first)
+    doc[:id] = doc['id'].try(:first) if doc
     doc
   end
 


### PR DESCRIPTION
Fixes #360 

Checks if a doc is present. I'm not sure what the failure scenarios are here of why this happens, but should allow indexing to not fail