### PR TITLE
add production database timeouts

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -25,3 +25,7 @@ production:
   database: db/production.sqlite3
   encoding: utf8mb4
   collation: utf8mb4_unicode_ci
+  connect_timeout: 1
+  read_timeout: 1
+  write_timeout: 1
+  checkout_timeout: 5


### PR DESCRIPTION
In stage and prod envs, getting a lot of failed timeout errors in anno reindexing

Adding this based off of:
 - https://github.com/ankane/the-ultimate-guide-to-ruby-timeouts/blob/master/README.md#mysql2-adapter
 - https://github.com/ankane/production_rails

/shrug?