### PR TITLE
set viewer config which spotlight will use for item embed fixes #307

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -22,6 +22,8 @@ class CatalogController < ApplicationController
     config.view.masonry.partials = [:index]
     config.view.slideshow.partials = [:index]
 
+    config.view.embed.partials = [:viewer]
+
     config.index.document_actions.clear
     config.show.document_actions.clear
     config.index.document_actions[:bookmark].if = false


### PR DESCRIPTION
This config was needed for: https://github.com/projectblacklight/spotlight/blob/master/app/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb#L10

![screen shot 2018-12-18 at 2 22 13 pm](https://user-images.githubusercontent.com/1656824/50183787-54c28c80-02d0-11e9-9373-1c4b3e0fae0d.png)
