### PR TITLE
Fixes #328 by using role when external or internal is role (other aut…

### DIFF
--- a/lib/name_display.rb
+++ b/lib/name_display.rb
@@ -28,13 +28,14 @@ class NameDisplay
     value = author.attribute('type').value
 
     value = author_type if value == 'person' && author_type
-    value = author_role if value == 'person' && other_author_role
 
     "[#{value}]"
   end
 
-  def other_author_role
-    author_role && %w[internal external].include?(author_role)
+  def role_or_type
+    return "[#{author_role}]" if author_role
+
+    type
   end
 
   def author_type
@@ -46,6 +47,6 @@ class NameDisplay
   end
 
   def display
-    [text, title, date, formal, type].compact.join(' ')
+    [text, title, date, formal, role_or_type].compact.join(' ')
   end
 end

--- a/lib/name_display.rb
+++ b/lib/name_display.rb
@@ -28,12 +28,21 @@ class NameDisplay
     value = author.attribute('type').value
 
     value = author_type if value == 'person' && author_type
+    value = author_role if value == 'person' && other_author_role
 
     "[#{value}]"
   end
 
+  def other_author_role
+    author_role && %w[internal external].include?(author_role)
+  end
+
   def author_type
     author.parent.parent.attribute('type')&.value
+  end
+
+  def author_role
+    author.parent.parent.attribute('role')&.value
   end
 
   def display

--- a/lib/traject/vatican_iiif_config.rb
+++ b/lib/traject/vatican_iiif_config.rb
@@ -66,13 +66,9 @@ compose ->(record, accumulator, _context) { accumulator << record.tei.xpath('//T
   to_field 'other_name_and_role_ssim', (accumulate do |resource, *_|
     resource.xpath("name[@role!='internal' and @role!='external' or not(@role)]").flat_map do |name|
       name.xpath("alias/authorityAuthor[@rif='aut']").map do |author|
-        author_name = author.text.gsub(/[,\.]$/, '')
-
-        if name['role'].present?
-          "#{author_name} [#{name['role']}]"
-        else
-          author_name
-        end
+        NameDisplay.new(
+          author
+        ).display
       end
     end
   end)

--- a/spec/features/vatican_iiif_resource_integration_spec.rb
+++ b/spec/features/vatican_iiif_resource_integration_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
     end
 
     it 'has other name' do
-      expect(document['other_name_ssim']).to eq ['Albini, Valeriano, sac., f. 1528-1545 [person]']
-      expect(document['other_name_and_role_ssim']).to eq ['Albini, Valeriano [scribe]']
+      expect(document['other_name_ssim']).to eq ['Albini, Valeriano, sac., f. 1528-1545 [scribe]']
+      expect(document['other_name_and_role_ssim']).to eq ['Albini, Valeriano, sac., f. 1528-1545 [scribe]']
     end
 
     it 'has place' do
@@ -156,7 +156,7 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
                                   'ms_height_tesim' => ['320'],
                                   'ms_language_ssim' => ['Greco.'],
                                   'ms_library_tesim' => ['Biblioteca Apostolica Vaticana'],
-                                  'ms_other_name_tesim' => ['Albini, Valeriano, sac., f. 1528-1545 [person]'],
+                                  'ms_other_name_tesim' => ['Albini, Valeriano, sac., f. 1528-1545 [scribe]'],
                                   'ms_shelfmark_tesim' => ['Barb.gr.252'],
                                   'ms_support_tesim' => ['chart.'],
                                   'ms_watermarks_tesim' => ['In prima parte codicis, officinarum chartariarum signa duo: ancora in circulo, stella superposita (cf. Briquet 588) et arcuballista in circulo, lilio superposito (Briquet 761); in secunda parte, signum unicum: sagittae, stella superposita (cf. Briquet 6300).'],
@@ -206,7 +206,7 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
           'Iohannes Chrysostomus, s., patriarca di Costantinopoli, 347-407. Opere spurie e dubbie [internal]'
         )
         expect(document['ms_other_name_tesim']).to include(
-          'Altemps (famiglia) [person]'
+          'Altemps (famiglia) [owner]'
         )
       end
     end
@@ -239,8 +239,8 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
           'Petrarca, Francesco, 1304-1374 [internal]'
         )
         expect(document['ms_other_name_tesim']).to include(
-          'Malpaghini, Giovanni, n. c. 1346-m. c. 1417 [person]',
-          'Bembo, Pietro, card., 1470-1547 [person]'
+          'Malpaghini, Giovanni, n. c. 1346-m. c. 1417 [scribe]',
+          'Bembo, Pietro, card., 1470-1547 [owner]'
         )
       end
     end

--- a/spec/features/vatican_iiif_resource_integration_spec.rb
+++ b/spec/features/vatican_iiif_resource_integration_spec.rb
@@ -233,10 +233,10 @@ RSpec.describe 'Bibliography resource integration test', type: :feature do
 
       it 'works with present and missing values' do
         expect(document['other_author_ssim']).to include(
-          'Petrarca, Francesco, 1304-1374 [person]'
+          'Petrarca, Francesco, 1304-1374 [internal]'
         )
         expect(document['ms_other_author_tesim']).to include(
-          'Petrarca, Francesco, 1304-1374 [person]'
+          'Petrarca, Francesco, 1304-1374 [internal]'
         )
         expect(document['ms_other_name_tesim']).to include(
           'Malpaghini, Giovanni, n. c. 1346-m. c. 1417 [person]',


### PR DESCRIPTION
…hor)

I __think__ this is the right logic now. I've been reading through #328 a few times. But the idea here is...

When an author's `type == person` and the author's parent's parent has the role `internal or external` use that role instead of the type.

/shrug

## UPDATE

Final commit, uses same display logic everywhere for names, and uses role to take precedence everywhere.