### PR TITLE
Fixes an issue where the MiradorBlock was unable to render on edit page

### DIFF
--- a/app/assets/javascripts/zpotlight/blocks/mirador_block.js
+++ b/app/assets/javascripts/zpotlight/blocks/mirador_block.js
@@ -137,7 +137,7 @@ SirTrevor.Blocks.Mirador = (function() {
         '</div>',
         '<div>',
           '<label for="<%= blockID + "_text"  %>" class="control-label"><%= i18n.t("blocks:mirador:text_label") %></label>',
-          '<textarea name="text" class="form-control"></textarea>',
+          '<textarea class="st-text-block" name="text" class="form-control"></textarea>',
         '</div>',
         '<div>',
           '<label for="<%= blockID + "_caption"  %>" class="control-label"><%= i18n.t("blocks:mirador:caption_label") %></label>',

--- a/app/assets/javascripts/zpotlight/blocks/mirador_block.js
+++ b/app/assets/javascripts/zpotlight/blocks/mirador_block.js
@@ -137,7 +137,7 @@ SirTrevor.Blocks.Mirador = (function() {
         '</div>',
         '<div>',
           '<label for="<%= blockID + "_text"  %>" class="control-label"><%= i18n.t("blocks:mirador:text_label") %></label>',
-          '<textarea class="st-text-block" name="text" class="form-control"></textarea>',
+          '<div id="<%= blockID + "_text"  %>" class="st-text-block form-control" contenteditable="true"></div>',
         '</div>',
         '<div>',
           '<label for="<%= blockID + "_caption"  %>" class="control-label"><%= i18n.t("blocks:mirador:caption_label") %></label>',

--- a/app/views/spotlight/sir_trevor/blocks/_mirador_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_mirador_block.html.erb
@@ -1,6 +1,6 @@
 <div class="st__content-block st__content-block--mirador">
   <h3><%= mirador_block.heading %></h3>
-  <p><%= mirador_block.text %></p>
+  <p><%= sir_trevor_markdown mirador_block.text %></p>
 
   <iframe
       src="<%= mirador_index_path(

--- a/spec/features/mirador_widget_spec.rb
+++ b/spec/features/mirador_widget_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Mirador Block', type: :feature, js: true do
       add_widget 'mirador'
 
       page.all('input[name="heading"]').first.set('The Heading')
-      page.all('textarea[name="text"]').first.set('The Text')
+      page.all('div[contenteditable="true"]').first.set('The Text')
       page.all('input[name="caption"]').first.set('The Caption')
 
       expect(page).to have_css '[data-behavior="nestable"]'


### PR DESCRIPTION
The upstream change here: https://github.com/projectblacklight/spotlight/pull/2161 changed the logic a bit about when and how `this.setTextBlockHTML` might be called. Since there were no `st-text-block` elements found, `this.hasTextBlock()` would always return false. This wasn't necessarily true, so we needed to add a `st-text-block` class to the `textarea` so that the appropriate html updating would happen in all the correct places.

Fixes an issue reported in an email on 04.29.2019