### PR TITLE
Discards the ActiveJob::DeserializationError error fixes #413

### DIFF
--- a/app/jobs/index_annotation_job.rb
+++ b/app/jobs/index_annotation_job.rb
@@ -1,5 +1,9 @@
 # Index an annotot annotation into solr, associated with the correct exhibit
 class IndexAnnotationJob < ApplicationJob
+  discard_on ActiveJob::DeserializationError do |_job, error|
+    Rails.logger.error("Skipping job because of ActiveJob::DeserializationError (#{error.message})")
+  end
+
   def perform(annotation)
     if annotation.destroyed?
       destroy(annotation)


### PR DESCRIPTION
Related to https://app.honeybadger.io/projects/55864/faults/49377921

The BAV team is noticing this error continually happens for annotations that may have been deleted, but perhaps their references in `AnnotationResources` were not cleaned up.

Potentially also fixes #369 