### PR TITLE
Turn on mirror in Mirador viewer fixes #414

### DIFF
--- a/app/helpers/mirador_helper.rb
+++ b/app/helpers/mirador_helper.rb
@@ -34,6 +34,16 @@ module MiradorHelper
         options: {
           endpoint: annotot_path
         }
+      },
+      windowSettings: {
+        canvasControls: {
+          imageManipulation: {
+            manipulationLayer: true,
+            controls: {
+              mirror: true
+            }
+          }
+        }
       }
     }
   end

--- a/spec/helpers/mirador_helper_spec.rb
+++ b/spec/helpers/mirador_helper_spec.rb
@@ -37,5 +37,13 @@ RSpec.describe MiradorHelper, type: :helper do
       expect(mirador_options[:annotationEndpoint][:module]).to eq 'AnnototEndpoint'
       expect(mirador_options[:annotationEndpoint][:options][:endpoint]).to eq '/annotations'
     end
+
+    it 'turns on the mirror' do
+      mirador_options = mirador_options(manifest, nil)
+      expect(mirador_options[:windowSettings][:canvasControls][:imageManipulation][:manipulationLayer])
+        .to be true
+      expect(mirador_options[:windowSettings][:canvasControls][:imageManipulation][:controls][:mirror])
+        .to be true
+    end
   end
 end


### PR DESCRIPTION
This fixes #414 for show page miradors.

@blalbrit please note that already configured feature page widgets may **not** get the mirror.

![mirror](https://user-images.githubusercontent.com/1656824/59848761-355df800-9323-11e9-9517-1d5dda4039a0.gif)
