### PR TITLE
Basic Google Analytics support enabled fixes #412

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -35,3 +35,4 @@
     </div>
   </div>
 </footer>
+<%= render 'shared/analytics' %>

--- a/config/initializers/spotlight_initializer.rb
+++ b/config/initializers/spotlight_initializer.rb
@@ -60,8 +60,9 @@ Spotlight::Engine.config.external_resources_partials += ['vatican_iiif_resources
 
 # ==> Google Analytics integration
 # Spotlight::Engine.config.analytics_provider = nil
+Spotlight::Engine.config.ga_anonymize_ip = true
 # Spotlight::Engine.config.ga_pkcs12_key_path = nil
-# Spotlight::Engine.config.ga_web_property_id = nil
+Spotlight::Engine.config.ga_web_property_id = 'UA-52480754-4'
 # Spotlight::Engine.config.ga_email = nil
 # Spotlight::Engine.config.ga_analytics_options = {}
 # Spotlight::Engine.config.ga_page_analytics_options = config.ga_analytics_options.merge(limit: 5)


### PR DESCRIPTION
This PR enables Google Analytics tracking snippet within BAV spotlight. Once this is deployed, BAV team should start to see traffic through their Google Analytics dashboard.

If additional integration with Spotlight exhibits is needed, we will need additional information/collaboration to support (probably not needed at this point).