### PR TITLE
Limit PaperTrail versions.

### DIFF
--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,0 +1,2 @@
+# Limit: 2 versions per record (1 most recent, plus a 'create' event)
+PaperTrail.config.version_limit = 1


### PR DESCRIPTION
See https://github.com/paper-trail-gem/paper_trail#2e-limiting-the-number-of-versions-created